### PR TITLE
add filter for containerd event

### DIFF
--- a/pkg/server/container_status.go
+++ b/pkg/server/container_status.go
@@ -40,7 +40,7 @@ func (c *criContainerdService) ContainerStatus(ctx context.Context, r *runtime.C
 	// * ImageSpec in container config is image ID.
 	// * ImageSpec in container status is image tag.
 	// * ImageRef in container status is repo digest.
-	spec := container.Metadata.Config.GetImage()
+	spec := container.Config.GetImage()
 	imageRef := container.ImageRef
 	image, err := c.imageStore.Get(imageRef)
 	if err != nil {


### PR DESCRIPTION
goal:
1. improve cri-containerd performance
2. clean log.
There are many useless info in log.
```
I1208 15:49:43.785508   12909 events.go:73] Received container event timestamp - 2017-12-08 07:49:43.784790728 +0000 UTC, namespace - "k8s.io", topic - "/images/create"
I1208 15:49:43.786397   12909 image_pull.go:111] Unpack image "busybox"
I1208 15:49:43.903693   12909 events.go:73] Received container event timestamp - 2017-12-08 07:49:43.903308963 +0000 UTC, namespace - "k8s.io", topic - "/images/update"
I1208 15:49:43.905175   12909 events.go:73] Received container event timestamp - 2017-12-08 07:49:43.90488295 +0000 UTC, namespace - "k8s.io", topic - "/images/create"
I1208 15:49:43.920262   12909 events.go:73] Received container event timestamp - 2017-12-08 07:49:43.919800908 +0000 UTC, namespace - "k8s.io", topic - "/images/create"
```
Signed-off-by: yason <yan.xuean@zte.com.cn>