### PR TITLE
Add initial version of plugin mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,13 @@ jobs:
         - make install.tools
         - make .gitvalidation
         - make binaries
+        - make plugin
       go: 1.9.x
     - script:
         - make install.tools
         - make .gitvalidation
         - make binaries
+        - make plugin
       go: tip
     - stage: Test
       script:
@@ -49,5 +51,14 @@ jobs:
         - cat /tmp/test-integration/cri-containerd.log
         - cat /tmp/test-integration/containerd.log
         - cat /tmp/test-cri/cri-containerd.log
+        - cat /tmp/test-cri/containerd.log
+      go: 1.9.x
+    - script:
+        - make install.deps COOK_CONTAINERD=true
+        - make test-integration STANDALONE_CRI_CONTAINERD=false
+        - make test-cri STANDALONE_CRI_CONTAINERD=false
+      after_script:
+        # Abuse travis to preserve the log.
+        - cat /tmp/test-integration/containerd.log
         - cat /tmp/test-cri/containerd.log
       go: 1.9.x

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ TARBALL := $(TARBALL_PREFIX)-$(VERSION).$(GOOS)-$(GOARCH).tar.gz
 BUILD_TAGS := seccomp apparmor
 GO_LDFLAGS := -X $(PROJECT)/pkg/version.CRIContainerdVersion=$(VERSION)
 SOURCES := $(shell find cmd/ pkg/ vendor/ -name '*.go')
+PLUGIN_SOURCES := $(shell ls *.go)
 INTEGRATION_SOURCES := $(shell find integration/ -name '*.go')
 
 all: binaries
@@ -41,6 +42,7 @@ help:
 	@echo
 	@echo " * 'install'          - Install binaries to system locations"
 	@echo " * 'binaries'         - Build cri-containerd"
+	@echo " * 'plugin'           - Build cri-containerd as a plugin package"
 	@echo " * 'static-binaries   - Build static cri-containerd"
 	@echo " * 'release'          - Build release tarball"
 	@echo " * 'push'             - Push release tarball to GCS"
@@ -107,6 +109,13 @@ clean:
 
 binaries: $(BUILD_DIR)/cri-containerd
 
+# TODO(random-liu): Make this only build when source files change and
+# add this to target all.
+plugin: $(PLUGIN_SOURCES) $(SOURCES)
+	$(GO) build -tags '$(BUILD_TAGS)' \
+		-ldflags '$(GO_LDFLAGS)' \
+		-gcflags '$(GO_GCFLAGS)' \
+
 static-binaries: GO_LDFLAGS += -extldflags "-fno-PIC -static"
 static-binaries: $(BUILD_DIR)/cri-containerd
 
@@ -156,6 +165,7 @@ install.tools: .install.gitvalidation .install.gometalinter
 .PHONY: \
 	binaries \
 	static-binaries \
+	plugin \
 	release \
 	push \
 	boiler \

--- a/cmd/cri-containerd/options/options.go
+++ b/cmd/cri-containerd/options/options.go
@@ -116,7 +116,7 @@ func NewCRIContainerdOptions() *CRIContainerdOptions {
 
 // AddFlags adds cri-containerd command line options to pflag.
 func (c *CRIContainerdOptions) AddFlags(fs *pflag.FlagSet) {
-	defaults := defaultConfig()
+	defaults := DefaultConfig()
 	fs.StringVar(&c.ConfigFilePath, configFilePathArgName,
 		defaultConfigFilePath, "Path to the config file.")
 	fs.StringVar(&c.SocketPath, "socket-path",
@@ -192,7 +192,7 @@ func (c *CRIContainerdOptions) InitFlags(fs *pflag.FlagSet) error {
 
 // PrintDefaultTomlConfig print default toml config of cri-containerd.
 func PrintDefaultTomlConfig() {
-	if err := toml.NewEncoder(os.Stdout).Encode(defaultConfig()); err != nil {
+	if err := toml.NewEncoder(os.Stdout).Encode(DefaultConfig()); err != nil {
 		fmt.Println(err)
 		return
 	}
@@ -200,13 +200,13 @@ func PrintDefaultTomlConfig() {
 
 // AddGRPCFlags add flags for grpc connection.
 func AddGRPCFlags(fs *pflag.FlagSet) (*string, *time.Duration) {
-	endpoint := fs.String("endpoint", defaultConfig().SocketPath, "cri-containerd endpoint.")
+	endpoint := fs.String("endpoint", DefaultConfig().SocketPath, "cri-containerd endpoint.")
 	timeout := fs.Duration("timeout", connectionTimeout, "cri-containerd connection timeout.")
 	return endpoint, timeout
 }
 
-// defaultConfig returns default configurations of cri-containerd.
-func defaultConfig() Config {
+// DefaultConfig returns default configurations of cri-containerd.
+func DefaultConfig() Config {
 	return Config{
 		ContainerdConfig: ContainerdConfig{
 			RootDir:       "/var/lib/containerd",

--- a/cri.go
+++ b/cri.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 The Containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cri
+
+import (
+	"github.com/containerd/containerd/plugin"
+	"github.com/golang/glog"
+
+	"github.com/containerd/cri-containerd/cmd/cri-containerd/options"
+	"github.com/containerd/cri-containerd/pkg/server"
+)
+
+// Register CRI service plugin
+func init() {
+	plugin.Register(&plugin.Registration{
+		// In fact, cri is not strictly a GRPC plugin now.
+		Type: plugin.GRPCPlugin,
+		ID:   "cri",
+		Requires: []plugin.Type{
+			plugin.RuntimePlugin,
+			plugin.SnapshotPlugin,
+			plugin.TaskMonitorPlugin,
+			plugin.DiffPlugin,
+			plugin.MetadataPlugin,
+			plugin.ContentPlugin,
+			plugin.GCPlugin,
+		},
+		InitFn: initCRIService,
+	})
+}
+
+func initCRIService(_ *plugin.InitContext) (interface{}, error) {
+	// TODO(random-liu): Support Config through Registration.Config.
+	// TODO(random-liu): Validate the configuration.
+	// TODO(random-liu): Leverage other fields in InitContext, such as Root.
+	// TODO(random-liu): Register GRPC service onto containerd GRPC server.
+	// TODO(random-liu): Separate cri plugin config from cri-containerd server config,
+	// because many options only make sense to cri-containerd server.
+	// TODO(random-liu): Change all glog to logrus.
+	// TODO(random-liu): Handle graceful stop.
+	c := options.DefaultConfig()
+	glog.V(0).Infof("Start cri plugin with config %+v", c)
+	// Use a goroutine to start cri service. The reason is that currently
+	// cri service requires containerd to be running.
+	// TODO(random-liu): Resolve the circular dependency.
+	go func() {
+		s, err := server.NewCRIContainerdService(c)
+		if err != nil {
+			glog.Exitf("Failed to create CRI service: %v", err)
+		}
+		if err := s.Run(); err != nil {
+			glog.Exitf("Failed to run CRI grpc server: %v", err)
+		}
+	}()
+	return nil, nil
+}

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -29,7 +29,9 @@ mkdir -p ${REPORT_DIR}
 test_setup ${REPORT_DIR}
 
 # Run integration test.
-sudo ${ROOT}/_output/integration.test --test.run="${FOCUS}" --test.v
+# Set STANDALONE_CRI_CONTAINERD so that integration test can see it.
+# Some integration test needs the env to skip itself.
+sudo STANDALONE_CRI_CONTAINERD=${STANDALONE_CRI_CONTAINERD} ${ROOT}/_output/integration.test --test.run="${FOCUS}" --test.v
 test_exit_code=$?
 
 test_teardown

--- a/hack/test-utils.sh
+++ b/hack/test-utils.sh
@@ -21,6 +21,8 @@ source ${ROOT}/hack/versions
 CRI_CONTAINERD_FLAGS=${CRI_CONTAINERD_FLAGS:-""}
 # RESTART_WAIT_PERIOD is the period to wait before restarting cri-containerd/containerd.
 RESTART_WAIT_PERIOD=${RESTART_WAIT_PERIOD:-10}
+# STANDALONE_CRI_CONTAINERD indicates whether to run standalone cri-containerd.
+STANDALONE_CRI_CONTAINERD=${STANDALONE_CRI_CONTAINERD:-true}
 
 CRICONTAINERD_SOCK=/var/run/cri-containerd.sock
 
@@ -48,9 +50,11 @@ test_setup() {
   readiness_check "sudo ctr version"
 
   # Start cri-containerd
-  keepalive "sudo ${ROOT}/_output/cri-containerd --alsologtostderr --v 4 ${CRI_CONTAINERD_FLAGS}" \
-	  ${RESTART_WAIT_PERIOD} &> ${report_dir}/cri-containerd.log &
-  cri_containerd_pid=$!
+  if ${STANDALONE_CRI_CONTAINERD}; then
+    keepalive "sudo ${ROOT}/_output/cri-containerd --alsologtostderr --v 4 ${CRI_CONTAINERD_FLAGS}" \
+      ${RESTART_WAIT_PERIOD} &> ${report_dir}/cri-containerd.log &
+    cri_containerd_pid=$!
+  fi
   readiness_check "sudo ${GOPATH}/bin/crictl --runtime-endpoint=${CRICONTAINERD_SOCK} info"
 }
 

--- a/integration/restart_test.go
+++ b/integration/restart_test.go
@@ -31,8 +31,12 @@ import (
 )
 
 // Restart test must run sequentially.
+// NOTE(random-liu): Current restart test only support standalone cri-containerd mode.
 
 func TestSandboxAcrossCRIContainerdRestart(t *testing.T) {
+	if os.Getenv(standaloneEnvKey) == "false" {
+		t.Skip("Skip because cri-containerd does not run in standalone mode")
+	}
 	ctx := context.Background()
 	sandboxNS := "sandbox-restart-cri-containerd"
 	sandboxes := []struct {
@@ -149,6 +153,9 @@ func TestSandboxAcrossCRIContainerdRestart(t *testing.T) {
 // teardown the network properly.
 // This test uses host network sandbox to avoid resource leakage.
 func TestSandboxDeletionAcrossCRIContainerdRestart(t *testing.T) {
+	if os.Getenv(standaloneEnvKey) == "false" {
+		t.Skip("Skip because cri-containerd does not run in standalone mode")
+	}
 	ctx := context.Background()
 	sandboxNS := "sandbox-delete-restart-cri-containerd"
 	t.Logf("Make sure no sandbox is running before test")

--- a/integration/test_utils.go
+++ b/integration/test_utils.go
@@ -41,6 +41,7 @@ const (
 	containerdEndpoint    = "/run/containerd/containerd.sock"
 	criContainerdEndpoint = "/var/run/cri-containerd.sock"
 	criContainerdRoot     = "/var/lib/cri-containerd"
+	standaloneEnvKey      = "STANDALONE_CRI_CONTAINERD"
 )
 
 var (


### PR DESCRIPTION
This PR:
1) Added `cri.go`, which implements the containerd plugin interface. Containerd can import cri plugin by simply adding:
```go
import _ "github.com/kubernetes-incubator/cri-containerd"
```
2) Added `make install.deps COOK_CONTAINERD=true` mode, which will automatically update vendored CRI plugin in containerd before building it.
3) Added integration test for the plugin mode in travis.

Please note that:
1) Build `cri-containerd` as binary plugin doesn't work at all. I tried it. One problem is that cri-containerd and containerd import many same packages, and init functions in those packages will run twice. Once when containerd starts, another one when the binary plugin is loaded, which is apparently unacceptable. Thus vendor cri-containerd into containerd become the only option.
2) This is only the first step, there are many TODOs in cri.go to make the integration more seamless, which we'll address as a next step.

@crosbymichael @stevvooe @dmcgowan @mlaventure @kubernetes-incubator/reviewers-cri-containerd 
  
  