### PR TITLE
fix kubernetes-incubator links

### DIFF
--- a/contrib/ansible/README.md
+++ b/contrib/ansible/README.md
@@ -1,7 +1,7 @@
 # Kubernetes Cluster with Containerd and CRI-Containerd
 <p align="center">
-<img src="https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png" width="50" height="50"> 
-<img src="https://github.com/containerd/containerd/blob/master/docs/images/containerd-dark.png" width="200" > 
+<img src="https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png" width="50" height="50">
+<img src="https://github.com/containerd/containerd/blob/master/docs/images/containerd-dark.png" width="200" >
 </p>
 
 
@@ -114,7 +114,7 @@ Node join complete:
 
 Run 'kubectl get nodes' on the master to see this machine join.
 ```
-At the end of Step 3 you should have a kubernetes cluster up and running and ready for deployment. 
+At the end of Step 3 you should have a kubernetes cluster up and running and ready for deployment.
 
 ## Step 4:
 Please follow the instructions [here](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#pod-network) to deploy CNI network plugins and start a demo app.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,7 +57,7 @@ Information about the binaries in the release tarball:
 |   containerd/containerd-shim   |   overlay, btrfs  | linux |     amd64    |
 
 If you have other requirements for the binaries, e.g. selinux support, another architecture support etc., you need to build the binaries yourself following [the instructions](../README.md#getting-started-for-developers).
- 
+
 ### Download
 
 The release tarball could be downloaded from either of the following sources:


### PR DESCRIPTION
This pr is one of a two or more fixes to the docs as a part of the move from kubernetes-incubator to our new github.com/containerd home.

First stage fix for the docs is just to move the links from kubernetes-incubator/cri-containerd to containerd/cri-containerd.

Next stage will be to modify the docs appropriately to address cri-containerd becoming a plugin within containerd, and possibly to move the repo from containerd/cri-containerd to containerd/cri or to containerd/cri-plugin etc.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>