### PR TITLE
glog to logrus

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ sudo containerd
 ```
 2. Start `cri-containerd` as root in a second terminal:
 ```bash
-sudo cri-containerd -v 2 --alsologtostderr
+sudo cri-containerd
 ```
 3. From the Kubernetes project directory startup a local cluster using `cri-containerd`:
 ```bash

--- a/cluster/gce/cloud-init/master.yaml
+++ b/cluster/gce/cloud-init/master.yaml
@@ -82,7 +82,7 @@ write_files:
       # cri-containerd on master uses the cni binary and config in the
       # release tarball.
       ExecStart=/home/cri-containerd/usr/local/bin/cri-containerd \
-        --logtostderr --v=4 \
+        --log-level=debug \
         --network-bin-dir=/home/cri-containerd/opt/cni/bin \
         --network-conf-dir=/home/cri-containerd/etc/cni/net.d
 

--- a/cluster/gce/cloud-init/node.yaml
+++ b/cluster/gce/cloud-init/node.yaml
@@ -85,7 +85,7 @@ write_files:
       # Point to /home/kubernetes/bin where calico setup cni binary in kube-up.sh.
       # Point to /etc/cni/net.d where calico put cni config in kube-up.sh.
       ExecStart=/home/cri-containerd/usr/local/bin/cri-containerd \
-        --logtostderr --v=4 \
+        --log-level=debug \
         --network-bin-dir=/home/kubernetes/bin \
         --network-conf-dir=/etc/cni/net.d
 

--- a/cmd/cri-containerd/options/options.go
+++ b/cmd/cri-containerd/options/options.go
@@ -99,13 +99,15 @@ type Config struct {
 	// SkipImageFSUUID skips retrieving imagefs uuid.
 	// TODO(random-liu): Remove this after we find a generic way to get imagefs uuid.
 	SkipImageFSUUID bool `toml:"skip_imagefs_uuid" json:"skipImageFSUUID,omitempty"`
+	// LogLevel is the logrus log level.
+	LogLevel string `toml:"log_level" json:"logLevel,omitempty"`
 }
 
 // CRIContainerdOptions contains cri-containerd command line and toml options.
 type CRIContainerdOptions struct {
 	// Config contains cri-containerd toml config
 	Config
-	// Path to the TOML config file.
+	// ConfigFilePath is the path to the TOML config file.
 	ConfigFilePath string `toml:"-"`
 }
 
@@ -117,6 +119,8 @@ func NewCRIContainerdOptions() *CRIContainerdOptions {
 // AddFlags adds cri-containerd command line options to pflag.
 func (c *CRIContainerdOptions) AddFlags(fs *pflag.FlagSet) {
 	defaults := DefaultConfig()
+	fs.StringVar(&c.LogLevel, "log-level",
+		"info", "Set the logging level [trace, debug, info, warn, error, fatal, panic].")
 	fs.StringVar(&c.ConfigFilePath, configFilePathArgName,
 		defaultConfigFilePath, "Path to the config file.")
 	fs.StringVar(&c.SocketPath, "socket-path",

--- a/contrib/systemd-units/cri-containerd.service
+++ b/contrib/systemd-units/cri-containerd.service
@@ -11,7 +11,7 @@ LimitNOFILE=1048576
 # in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNPROC=infinity
 LimitCORE=infinity
-ExecStart=/usr/local/bin/cri-containerd --logtostderr
+ExecStart=/usr/local/bin/cri-containerd
 
 [Install]
 WantedBy=multi-user.target

--- a/hack/test-utils.sh
+++ b/hack/test-utils.sh
@@ -51,7 +51,7 @@ test_setup() {
 
   # Start cri-containerd
   if ${STANDALONE_CRI_CONTAINERD}; then
-    keepalive "sudo ${ROOT}/_output/cri-containerd --alsologtostderr --v 4 ${CRI_CONTAINERD_FLAGS}" \
+    keepalive "sudo ${ROOT}/_output/cri-containerd --log-level=debug ${CRI_CONTAINERD_FLAGS}" \
       ${RESTART_WAIT_PERIOD} &> ${report_dir}/cri-containerd.log &
     cri_containerd_pid=$!
   fi

--- a/integration/test_utils.go
+++ b/integration/test_utils.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd"
-	"github.com/golang/glog"
+	"github.com/sirupsen/logrus"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 	"k8s.io/kubernetes/pkg/kubelet/remote"
@@ -53,7 +53,7 @@ var (
 
 func init() {
 	if err := ConnectDaemons(); err != nil {
-		glog.Exitf("Failed to connect daemons: %v", err)
+		logrus.WithError(err).Fatalf("Failed to connect daemons")
 	}
 }
 

--- a/pkg/containerd/opts/container.go
+++ b/pkg/containerd/opts/container.go
@@ -27,8 +27,8 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/fs"
 	"github.com/containerd/containerd/mount"
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // WithNewSnapshot wraps `containerd.WithNewSnapshot` so that if creating the
@@ -81,7 +81,7 @@ func WithVolumes(volumeMounts map[string]string) containerd.NewContainerOpts {
 		}
 		defer func() {
 			if uerr := mount.Unmount(root, 0); uerr != nil {
-				glog.Errorf("Failed to unmount snapshot %q: %v", c.SnapshotKey, uerr)
+				logrus.WithError(uerr).Errorf("Failed to unmount snapshot %q", c.SnapshotKey)
 				if err == nil {
 					err = uerr
 				}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2018 The Containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import "github.com/sirupsen/logrus"
+
+// TODO(random-liu): Add trace support in containerd.
+
+// TraceLevel is the log level for trace.
+const TraceLevel = logrus.Level(uint32(logrus.DebugLevel + 1))
+
+// ParseLevel takes a string level and returns the Logrus log level constant.
+func ParseLevel(lvl string) (logrus.Level, error) {
+	if lvl == "trace" {
+		return TraceLevel, nil
+	}
+	return logrus.ParseLevel(lvl)
+}
+
+// Trace logs a message at level Trace on the standard logger.
+func Trace(args ...interface{}) {
+	if logrus.GetLevel() >= TraceLevel {
+		logrus.Debug(args...)
+	}
+}
+
+// Tracef logs a message at level Trace on the standard logger.
+func Tracef(format string, args ...interface{}) {
+	if logrus.GetLevel() >= TraceLevel {
+		logrus.Debugf(format, args...)
+	}
+}

--- a/pkg/server/container_attach.go
+++ b/pkg/server/container_attach.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	"github.com/containerd/containerd"
-	"github.com/golang/glog"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
@@ -62,7 +62,7 @@ func (c *criContainerdService) attachContainer(ctx context.Context, id string, s
 	}
 	handleResizing(resize, func(size remotecommand.TerminalSize) {
 		if err := task.Resize(ctx, uint32(size.Width), uint32(size.Height)); err != nil {
-			glog.Errorf("Failed to resize task %q console: %v", id, err)
+			logrus.WithError(err).Errorf("Failed to resize task %q console", id)
 		}
 	})
 

--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/containerd/containerd"
 	containerdio "github.com/containerd/containerd/cio"
-	"github.com/golang/glog"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
@@ -133,7 +133,7 @@ func (c *criContainerdService) startContainer(ctx context.Context,
 	defer func() {
 		if retErr != nil {
 			if _, err := task.Delete(ctx, containerd.WithProcessKill); err != nil {
-				glog.Errorf("Failed to delete containerd task %q: %v", id, err)
+				logrus.WithError(err).Errorf("Failed to delete containerd task %q", id)
 			}
 		}
 	}()

--- a/pkg/server/container_status.go
+++ b/pkg/server/container_status.go
@@ -20,8 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/golang/glog"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
@@ -131,7 +131,7 @@ func toCRIContainerInfo(ctx context.Context, container containerstore.Container,
 	if err == nil {
 		ci.RuntimeSpec = spec
 	} else {
-		glog.Errorf("Failed to get container %q spec: %v", container.ID, err)
+		logrus.WithError(err).Errorf("Failed to get container %q spec", container.ID)
 	}
 
 	ctrInfo, err := container.Container.Info(ctx)
@@ -139,7 +139,7 @@ func toCRIContainerInfo(ctx context.Context, container containerstore.Container,
 		ci.SnapshotKey = ctrInfo.SnapshotKey
 		ci.Snapshotter = ctrInfo.Snapshotter
 	} else {
-		glog.Errorf("Failed to get container %q info: %v", container.ID, err)
+		logrus.WithError(err).Errorf("Failed to get container %q info", container.ID)
 	}
 
 	infoBytes, err := json.Marshal(ci)

--- a/pkg/server/container_update_resources.go
+++ b/pkg/server/container_update_resources.go
@@ -24,8 +24,8 @@ import (
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/typeurl"
-	"github.com/golang/glog"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
@@ -80,7 +80,7 @@ func (c *criContainerdService) updateContainerResources(ctx context.Context,
 		if retErr != nil {
 			// Reset spec on error.
 			if err := updateContainerSpec(ctx, cntr.Container, oldSpec); err != nil {
-				glog.Errorf("Failed to update spec %+v for container %q: %v", oldSpec, id, err)
+				logrus.WithError(err).Errorf("Failed to update spec %+v for container %q", oldSpec, id)
 			}
 		}
 	}()

--- a/pkg/server/image_load.go
+++ b/pkg/server/image_load.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/golang/glog"
+	"github.com/sirupsen/logrus"
 
 	api "github.com/containerd/cri-containerd/pkg/api/v1"
 	"github.com/containerd/cri-containerd/pkg/containerd/importer"
@@ -49,7 +49,7 @@ func (c *criContainerdService) LoadImage(ctx context.Context, r *api.LoadImageRe
 			return nil, fmt.Errorf("failed to get image %q: %v", repoTag, err)
 		}
 		if err := image.Unpack(ctx, c.config.ContainerdConfig.Snapshotter); err != nil {
-			glog.Warningf("Failed to unpack image %q: %v", repoTag, err)
+			logrus.WithError(err).Warnf("Failed to unpack image %q", repoTag)
 			// Do not fail image importing. Unpack will be retried when container creation.
 		}
 		info, err := getImageInfo(ctx, image)
@@ -74,7 +74,7 @@ func (c *criContainerdService) LoadImage(ctx context.Context, r *api.LoadImageRe
 		if err := c.imageStore.Add(img); err != nil {
 			return nil, fmt.Errorf("failed to add image %q into store: %v", id, err)
 		}
-		glog.V(4).Infof("Imported image with id %q, repo tag %q", id, repoTag)
+		logrus.Debugf("Imported image with id %q, repo tag %q", id, repoTag)
 	}
 	return &api.LoadImageResponse{Images: repoTags}, nil
 }

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -26,8 +26,8 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	containerdimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes/docker"
-	"github.com/golang/glog"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
@@ -86,7 +86,7 @@ func (c *criContainerdService) PullImage(ctx context.Context, r *runtime.PullIma
 	// TODO(random-liu): [P0] Avoid concurrent pulling/removing on the same image reference.
 	ref := namedRef.String()
 	if ref != imageRef {
-		glog.V(4).Infof("PullImage using normalized image ref: %q", ref)
+		logrus.Debugf("PullImage using normalized image ref: %q", ref)
 	}
 
 	resolver := docker.NewResolver(docker.ResolverOptions{
@@ -111,9 +111,9 @@ func (c *criContainerdService) PullImage(ctx context.Context, r *runtime.PullIma
 	}
 
 	// Do best effort unpack.
-	glog.V(4).Infof("Unpack image %q", imageRef)
+	logrus.Debugf("Unpack image %q", imageRef)
 	if err := image.Unpack(ctx, c.config.ContainerdConfig.Snapshotter); err != nil {
-		glog.Warningf("Failed to unpack image %q: %v", imageRef, err)
+		logrus.WithError(err).Warnf("Failed to unpack image %q", imageRef)
 		// Do not fail image pulling. Unpack will be retried before container creation.
 	}
 
@@ -134,7 +134,7 @@ func (c *criContainerdService) PullImage(ctx context.Context, r *runtime.PullIma
 		}
 	}
 
-	glog.V(4).Infof("Pulled image %q with image id %q, repo tag %q, repo digest %q", imageRef, imageID,
+	logrus.Debugf("Pulled image %q with image id %q, repo tag %q, repo digest %q", imageRef, imageID,
 		repoTag, repoDigest)
 	img := imagestore.Image{
 		ID:        imageID,

--- a/pkg/server/image_remove.go
+++ b/pkg/server/image_remove.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
-	"github.com/golang/glog"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
@@ -64,13 +64,13 @@ func (c *criContainerdService) RemoveImage(ctx context.Context, r *runtime.Remov
 			// but different ids generated from compressed contents - manifest digest.
 			// So we decide to leave it.
 			// After all, the user can override the repoTag by pulling image again.
-			glog.Errorf("Can't remove image,failed to get config for Image tag %q,id %q: %v", tag, image.ID, err)
+			logrus.WithError(err).Errorf("Can't remove image,failed to get config for Image tag %q,id %q", tag, image.ID)
 			image.RepoTags = append(image.RepoTags[:i], image.RepoTags[i+1:]...)
 			continue
 		}
 		cID := desc.Digest.String()
 		if cID != image.ID {
-			glog.V(4).Infof("Image tag %q for %q is outdated, it's currently used by %q", tag, image.ID, cID)
+			logrus.Debugf("Image tag %q for %q is outdated, it's currently used by %q", tag, image.ID, cID)
 			image.RepoTags = append(image.RepoTags[:i], image.RepoTags[i+1:]...)
 			continue
 		}

--- a/pkg/server/image_status.go
+++ b/pkg/server/image_status.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/golang/glog"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
@@ -95,7 +95,7 @@ func (c *criContainerdService) toCRIImageInfo(ctx context.Context, image *images
 	if err == nil {
 		info["info"] = string(m)
 	} else {
-		glog.Errorf("failed to marshal info %v: %v", imi, err)
+		logrus.WithError(err).Errorf("failed to marshal info %v", imi)
 		info["info"] = err.Error()
 	}
 

--- a/pkg/server/instrumented_service.go
+++ b/pkg/server/instrumented_service.go
@@ -17,11 +17,12 @@ limitations under the License.
 package server
 
 import (
-	"github.com/golang/glog"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
 	api "github.com/containerd/cri-containerd/pkg/api/v1"
+	"github.com/containerd/cri-containerd/pkg/log"
 )
 
 // instrumentedService wraps service and logs each operation.
@@ -34,86 +35,86 @@ func newInstrumentedService(c *criContainerdService) CRIContainerdService {
 }
 
 func (in *instrumentedService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandboxRequest) (res *runtime.RunPodSandboxResponse, err error) {
-	glog.V(2).Infof("RunPodSandbox with config %+v", r.GetConfig())
+	logrus.Infof("RunPodSandbox with config %+v", r.GetConfig())
 	defer func() {
 		if err != nil {
-			glog.Errorf("RunPodSandbox for %+v failed, error: %v", r.GetConfig().GetMetadata(), err)
+			logrus.WithError(err).Errorf("RunPodSandbox for %+v failed, error", r.GetConfig().GetMetadata())
 		} else {
-			glog.V(2).Infof("RunPodSandbox for %+v returns sandbox id %q", r.GetConfig().GetMetadata(), res.GetPodSandboxId())
+			logrus.Infof("RunPodSandbox for %+v returns sandbox id %q", r.GetConfig().GetMetadata(), res.GetPodSandboxId())
 		}
 	}()
 	return in.criContainerdService.RunPodSandbox(ctx, r)
 }
 
 func (in *instrumentedService) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandboxRequest) (res *runtime.ListPodSandboxResponse, err error) {
-	glog.V(5).Infof("ListPodSandbox with filter %+v", r.GetFilter())
+	log.Tracef("ListPodSandbox with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
-			glog.Errorf("ListPodSandbox failed, error: %v", err)
+			logrus.WithError(err).Error("ListPodSandbox failed")
 		} else {
-			glog.V(5).Infof("ListPodSandbox returns sandboxes %+v", res.GetItems())
+			log.Tracef("ListPodSandbox returns sandboxes %+v", res.GetItems())
 		}
 	}()
 	return in.criContainerdService.ListPodSandbox(ctx, r)
 }
 
 func (in *instrumentedService) PodSandboxStatus(ctx context.Context, r *runtime.PodSandboxStatusRequest) (res *runtime.PodSandboxStatusResponse, err error) {
-	glog.V(5).Infof("PodSandboxStatus for %q", r.GetPodSandboxId())
+	log.Tracef("PodSandboxStatus for %q", r.GetPodSandboxId())
 	defer func() {
 		if err != nil {
-			glog.Errorf("PodSandboxStatus for %q failed, error: %v", r.GetPodSandboxId(), err)
+			logrus.WithError(err).Errorf("PodSandboxStatus for %q failed", r.GetPodSandboxId())
 		} else {
-			glog.V(5).Infof("PodSandboxStatus for %q returns status %+v", r.GetPodSandboxId(), res.GetStatus())
+			log.Tracef("PodSandboxStatus for %q returns status %+v", r.GetPodSandboxId(), res.GetStatus())
 		}
 	}()
 	return in.criContainerdService.PodSandboxStatus(ctx, r)
 }
 
 func (in *instrumentedService) StopPodSandbox(ctx context.Context, r *runtime.StopPodSandboxRequest) (_ *runtime.StopPodSandboxResponse, err error) {
-	glog.V(2).Infof("StopPodSandbox for %q", r.GetPodSandboxId())
+	logrus.Infof("StopPodSandbox for %q", r.GetPodSandboxId())
 	defer func() {
 		if err != nil {
-			glog.Errorf("StopPodSandbox for %q failed, error: %v", r.GetPodSandboxId(), err)
+			logrus.WithError(err).Errorf("StopPodSandbox for %q failed", r.GetPodSandboxId())
 		} else {
-			glog.V(2).Infof("StopPodSandbox for %q returns successfully", r.GetPodSandboxId())
+			logrus.Infof("StopPodSandbox for %q returns successfully", r.GetPodSandboxId())
 		}
 	}()
 	return in.criContainerdService.StopPodSandbox(ctx, r)
 }
 
 func (in *instrumentedService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodSandboxRequest) (_ *runtime.RemovePodSandboxResponse, err error) {
-	glog.V(2).Infof("RemovePodSandbox for %q", r.GetPodSandboxId())
+	logrus.Infof("RemovePodSandbox for %q", r.GetPodSandboxId())
 	defer func() {
 		if err != nil {
-			glog.Errorf("RemovePodSandbox for %q failed, error: %v", r.GetPodSandboxId(), err)
+			logrus.WithError(err).Errorf("RemovePodSandbox for %q failed", r.GetPodSandboxId())
 		} else {
-			glog.V(2).Infof("RemovePodSandbox %q returns successfully", r.GetPodSandboxId())
+			logrus.Infof("RemovePodSandbox %q returns successfully", r.GetPodSandboxId())
 		}
 	}()
 	return in.criContainerdService.RemovePodSandbox(ctx, r)
 }
 
 func (in *instrumentedService) PortForward(ctx context.Context, r *runtime.PortForwardRequest) (res *runtime.PortForwardResponse, err error) {
-	glog.V(2).Infof("Portforward for %q port %v", r.GetPodSandboxId(), r.GetPort())
+	logrus.Infof("Portforward for %q port %v", r.GetPodSandboxId(), r.GetPort())
 	defer func() {
 		if err != nil {
-			glog.Errorf("Portforward for %q failed, error: %v", r.GetPodSandboxId(), err)
+			logrus.WithError(err).Errorf("Portforward for %q failed", r.GetPodSandboxId())
 		} else {
-			glog.V(2).Infof("Portforward for %q returns URL %q", r.GetPodSandboxId(), res.GetUrl())
+			logrus.Infof("Portforward for %q returns URL %q", r.GetPodSandboxId(), res.GetUrl())
 		}
 	}()
 	return in.criContainerdService.PortForward(ctx, r)
 }
 
 func (in *instrumentedService) CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) (res *runtime.CreateContainerResponse, err error) {
-	glog.V(2).Infof("CreateContainer within sandbox %q with container config %+v and sandbox config %+v",
+	logrus.Infof("CreateContainer within sandbox %q with container config %+v and sandbox config %+v",
 		r.GetPodSandboxId(), r.GetConfig(), r.GetSandboxConfig())
 	defer func() {
 		if err != nil {
-			glog.Errorf("CreateContainer within sandbox %q for %+v failed, error: %v",
-				r.GetPodSandboxId(), r.GetConfig().GetMetadata(), err)
+			logrus.WithError(err).Errorf("CreateContainer within sandbox %q for %+v failed",
+				r.GetPodSandboxId(), r.GetConfig().GetMetadata())
 		} else {
-			glog.V(2).Infof("CreateContainer within sandbox %q for %+v returns container id %q",
+			logrus.Infof("CreateContainer within sandbox %q for %+v returns container id %q",
 				r.GetPodSandboxId(), r.GetConfig().GetMetadata(), res.GetContainerId())
 		}
 	}()
@@ -121,24 +122,24 @@ func (in *instrumentedService) CreateContainer(ctx context.Context, r *runtime.C
 }
 
 func (in *instrumentedService) StartContainer(ctx context.Context, r *runtime.StartContainerRequest) (_ *runtime.StartContainerResponse, err error) {
-	glog.V(2).Infof("StartContainer for %q", r.GetContainerId())
+	logrus.Infof("StartContainer for %q", r.GetContainerId())
 	defer func() {
 		if err != nil {
-			glog.Errorf("StartContainer for %q failed, error: %v", r.GetContainerId(), err)
+			logrus.WithError(err).Errorf("StartContainer for %q failed", r.GetContainerId())
 		} else {
-			glog.V(2).Infof("StartContainer for %q returns successfully", r.GetContainerId())
+			logrus.Infof("StartContainer for %q returns successfully", r.GetContainerId())
 		}
 	}()
 	return in.criContainerdService.StartContainer(ctx, r)
 }
 
 func (in *instrumentedService) ListContainers(ctx context.Context, r *runtime.ListContainersRequest) (res *runtime.ListContainersResponse, err error) {
-	glog.V(5).Infof("ListContainers with filter %+v", r.GetFilter())
+	log.Tracef("ListContainers with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
-			glog.Errorf("ListContainers with filter %+v failed, error: %v", r.GetFilter(), err)
+			logrus.WithError(err).Errorf("ListContainers with filter %+v failed", r.GetFilter())
 		} else {
-			glog.V(5).Infof("ListContainers with filter %+v returns containers %+v",
+			log.Tracef("ListContainers with filter %+v returns containers %+v",
 				r.GetFilter(), res.GetContainers())
 		}
 	}()
@@ -146,49 +147,49 @@ func (in *instrumentedService) ListContainers(ctx context.Context, r *runtime.Li
 }
 
 func (in *instrumentedService) ContainerStatus(ctx context.Context, r *runtime.ContainerStatusRequest) (res *runtime.ContainerStatusResponse, err error) {
-	glog.V(5).Infof("ContainerStatus for %q", r.GetContainerId())
+	log.Tracef("ContainerStatus for %q", r.GetContainerId())
 	defer func() {
 		if err != nil {
-			glog.Errorf("ContainerStatus for %q failed, error: %v", r.GetContainerId(), err)
+			logrus.WithError(err).Errorf("ContainerStatus for %q failed", r.GetContainerId())
 		} else {
-			glog.V(5).Infof("ContainerStatus for %q returns status %+v", r.GetContainerId(), res.GetStatus())
+			log.Tracef("ContainerStatus for %q returns status %+v", r.GetContainerId(), res.GetStatus())
 		}
 	}()
 	return in.criContainerdService.ContainerStatus(ctx, r)
 }
 
 func (in *instrumentedService) StopContainer(ctx context.Context, r *runtime.StopContainerRequest) (res *runtime.StopContainerResponse, err error) {
-	glog.V(2).Infof("StopContainer for %q with timeout %d (s)", r.GetContainerId(), r.GetTimeout())
+	logrus.Infof("StopContainer for %q with timeout %d (s)", r.GetContainerId(), r.GetTimeout())
 	defer func() {
 		if err != nil {
-			glog.Errorf("StopContainer for %q failed, error: %v", r.GetContainerId(), err)
+			logrus.WithError(err).Errorf("StopContainer for %q failed", r.GetContainerId())
 		} else {
-			glog.V(2).Infof("StopContainer for %q returns successfully", r.GetContainerId())
+			logrus.Infof("StopContainer for %q returns successfully", r.GetContainerId())
 		}
 	}()
 	return in.criContainerdService.StopContainer(ctx, r)
 }
 
 func (in *instrumentedService) RemoveContainer(ctx context.Context, r *runtime.RemoveContainerRequest) (res *runtime.RemoveContainerResponse, err error) {
-	glog.V(2).Infof("RemoveContainer for %q", r.GetContainerId())
+	logrus.Infof("RemoveContainer for %q", r.GetContainerId())
 	defer func() {
 		if err != nil {
-			glog.Errorf("RemoveContainer for %q failed, error: %v", r.GetContainerId(), err)
+			logrus.WithError(err).Errorf("RemoveContainer for %q failed", r.GetContainerId())
 		} else {
-			glog.V(2).Infof("RemoveContainer for %q returns successfully", r.GetContainerId())
+			logrus.Infof("RemoveContainer for %q returns successfully", r.GetContainerId())
 		}
 	}()
 	return in.criContainerdService.RemoveContainer(ctx, r)
 }
 
 func (in *instrumentedService) ExecSync(ctx context.Context, r *runtime.ExecSyncRequest) (res *runtime.ExecSyncResponse, err error) {
-	glog.V(2).Infof("ExecSync for %q with command %+v and timeout %d (s)", r.GetContainerId(), r.GetCmd(), r.GetTimeout())
+	logrus.Infof("ExecSync for %q with command %+v and timeout %d (s)", r.GetContainerId(), r.GetCmd(), r.GetTimeout())
 	defer func() {
 		if err != nil {
-			glog.Errorf("ExecSync for %q failed, error: %v", r.GetContainerId(), err)
+			logrus.WithError(err).Errorf("ExecSync for %q failed", r.GetContainerId())
 		} else {
-			glog.V(2).Infof("ExecSync for %q returns with exit code %d", r.GetContainerId(), res.GetExitCode())
-			glog.V(4).Infof("ExecSync for %q outputs - stdout: %q, stderr: %q", r.GetContainerId(),
+			logrus.Infof("ExecSync for %q returns with exit code %d", r.GetContainerId(), res.GetExitCode())
+			logrus.Debugf("ExecSync for %q outputs - stdout: %q, stderr: %q", r.GetContainerId(),
 				res.GetStdout(), res.GetStderr())
 		}
 	}()
@@ -196,49 +197,49 @@ func (in *instrumentedService) ExecSync(ctx context.Context, r *runtime.ExecSync
 }
 
 func (in *instrumentedService) Exec(ctx context.Context, r *runtime.ExecRequest) (res *runtime.ExecResponse, err error) {
-	glog.V(2).Infof("Exec for %q with command %+v, tty %v and stdin %v",
+	logrus.Infof("Exec for %q with command %+v, tty %v and stdin %v",
 		r.GetContainerId(), r.GetCmd(), r.GetTty(), r.GetStdin())
 	defer func() {
 		if err != nil {
-			glog.Errorf("Exec for %q failed, error: %v", r.GetContainerId(), err)
+			logrus.WithError(err).Errorf("Exec for %q failed", r.GetContainerId())
 		} else {
-			glog.V(2).Infof("Exec for %q returns URL %q", r.GetContainerId(), res.GetUrl())
+			logrus.Infof("Exec for %q returns URL %q", r.GetContainerId(), res.GetUrl())
 		}
 	}()
 	return in.criContainerdService.Exec(ctx, r)
 }
 
 func (in *instrumentedService) Attach(ctx context.Context, r *runtime.AttachRequest) (res *runtime.AttachResponse, err error) {
-	glog.V(2).Infof("Attach for %q with tty %v and stdin %v", r.GetContainerId(), r.GetTty(), r.GetStdin())
+	logrus.Infof("Attach for %q with tty %v and stdin %v", r.GetContainerId(), r.GetTty(), r.GetStdin())
 	defer func() {
 		if err != nil {
-			glog.Errorf("Attach for %q failed, error: %v", r.GetContainerId(), err)
+			logrus.WithError(err).Errorf("Attach for %q failed", r.GetContainerId())
 		} else {
-			glog.V(2).Infof("Attach for %q returns URL %q", r.GetContainerId(), res.Url)
+			logrus.Infof("Attach for %q returns URL %q", r.GetContainerId(), res.Url)
 		}
 	}()
 	return in.criContainerdService.Attach(ctx, r)
 }
 
 func (in *instrumentedService) UpdateContainerResources(ctx context.Context, r *runtime.UpdateContainerResourcesRequest) (res *runtime.UpdateContainerResourcesResponse, err error) {
-	glog.V(2).Infof("UpdateContainerResources for %q with %+v", r.GetContainerId(), r.GetLinux())
+	logrus.Infof("UpdateContainerResources for %q with %+v", r.GetContainerId(), r.GetLinux())
 	defer func() {
 		if err != nil {
-			glog.Errorf("UpdateContainerResources for %q failed, error: %v", r.GetContainerId(), err)
+			logrus.WithError(err).Errorf("UpdateContainerResources for %q failed", r.GetContainerId())
 		} else {
-			glog.V(2).Infof("UpdateContainerResources for %q returns successfully", r.GetContainerId())
+			logrus.Infof("UpdateContainerResources for %q returns successfully", r.GetContainerId())
 		}
 	}()
 	return in.criContainerdService.UpdateContainerResources(ctx, r)
 }
 
 func (in *instrumentedService) PullImage(ctx context.Context, r *runtime.PullImageRequest) (res *runtime.PullImageResponse, err error) {
-	glog.V(2).Infof("PullImage %q with auth config %+v", r.GetImage().GetImage(), r.GetAuth())
+	logrus.Infof("PullImage %q with auth config %+v", r.GetImage().GetImage(), r.GetAuth())
 	defer func() {
 		if err != nil {
-			glog.Errorf("PullImage %q failed, error: %v", r.GetImage().GetImage(), err)
+			logrus.WithError(err).Errorf("PullImage %q failed", r.GetImage().GetImage())
 		} else {
-			glog.V(2).Infof("PullImage %q returns image reference %q",
+			logrus.Infof("PullImage %q returns image reference %q",
 				r.GetImage().GetImage(), res.GetImageRef())
 		}
 	}()
@@ -246,12 +247,12 @@ func (in *instrumentedService) PullImage(ctx context.Context, r *runtime.PullIma
 }
 
 func (in *instrumentedService) ListImages(ctx context.Context, r *runtime.ListImagesRequest) (res *runtime.ListImagesResponse, err error) {
-	glog.V(5).Infof("ListImages with filter %+v", r.GetFilter())
+	log.Tracef("ListImages with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
-			glog.Errorf("ListImages with filter %+v failed, error: %v", r.GetFilter(), err)
+			logrus.WithError(err).Errorf("ListImages with filter %+v failed", r.GetFilter())
 		} else {
-			glog.V(5).Infof("ListImages with filter %+v returns image list %+v",
+			log.Tracef("ListImages with filter %+v returns image list %+v",
 				r.GetFilter(), res.GetImages())
 		}
 	}()
@@ -259,12 +260,12 @@ func (in *instrumentedService) ListImages(ctx context.Context, r *runtime.ListIm
 }
 
 func (in *instrumentedService) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequest) (res *runtime.ImageStatusResponse, err error) {
-	glog.V(5).Infof("ImageStatus for %q", r.GetImage().GetImage())
+	log.Tracef("ImageStatus for %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
-			glog.Errorf("ImageStatus for %q failed, error: %v", r.GetImage().GetImage(), err)
+			logrus.WithError(err).Errorf("ImageStatus for %q failed", r.GetImage().GetImage())
 		} else {
-			glog.V(5).Infof("ImageStatus for %q returns image status %+v",
+			log.Tracef("ImageStatus for %q returns image status %+v",
 				r.GetImage().GetImage(), res.GetImage())
 		}
 	}()
@@ -272,60 +273,60 @@ func (in *instrumentedService) ImageStatus(ctx context.Context, r *runtime.Image
 }
 
 func (in *instrumentedService) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequest) (_ *runtime.RemoveImageResponse, err error) {
-	glog.V(2).Infof("RemoveImage %q", r.GetImage().GetImage())
+	logrus.Infof("RemoveImage %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
-			glog.Errorf("RemoveImage %q failed, error: %v", r.GetImage().GetImage(), err)
+			logrus.WithError(err).Errorf("RemoveImage %q failed", r.GetImage().GetImage())
 		} else {
-			glog.V(2).Infof("RemoveImage %q returns successfully", r.GetImage().GetImage())
+			logrus.Infof("RemoveImage %q returns successfully", r.GetImage().GetImage())
 		}
 	}()
 	return in.criContainerdService.RemoveImage(ctx, r)
 }
 
 func (in *instrumentedService) ImageFsInfo(ctx context.Context, r *runtime.ImageFsInfoRequest) (res *runtime.ImageFsInfoResponse, err error) {
-	glog.V(4).Infof("ImageFsInfo")
+	logrus.Debugf("ImageFsInfo")
 	defer func() {
 		if err != nil {
-			glog.Errorf("ImageFsInfo failed, error: %v", err)
+			logrus.WithError(err).Error("ImageFsInfo failed")
 		} else {
-			glog.V(4).Infof("ImageFsInfo returns filesystem info %+v", res.ImageFilesystems)
+			logrus.Debugf("ImageFsInfo returns filesystem info %+v", res.ImageFilesystems)
 		}
 	}()
 	return in.criContainerdService.ImageFsInfo(ctx, r)
 }
 
 func (in *instrumentedService) ContainerStats(ctx context.Context, r *runtime.ContainerStatsRequest) (res *runtime.ContainerStatsResponse, err error) {
-	glog.V(4).Infof("ContainerStats for %q", r.GetContainerId())
+	logrus.Debugf("ContainerStats for %q", r.GetContainerId())
 	defer func() {
 		if err != nil {
-			glog.Errorf("ContainerStats for %q failed, error: %v", r.GetContainerId(), err)
+			logrus.WithError(err).Errorf("ContainerStats for %q failed", r.GetContainerId())
 		} else {
-			glog.V(4).Infof("ContainerStats for %q returns stats %+v", r.GetContainerId(), res.GetStats())
+			logrus.Debugf("ContainerStats for %q returns stats %+v", r.GetContainerId(), res.GetStats())
 		}
 	}()
 	return in.criContainerdService.ContainerStats(ctx, r)
 }
 
 func (in *instrumentedService) ListContainerStats(ctx context.Context, r *runtime.ListContainerStatsRequest) (res *runtime.ListContainerStatsResponse, err error) {
-	glog.V(5).Infof("ListContainerStats with filter %+v", r.GetFilter())
+	log.Tracef("ListContainerStats with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
-			glog.Errorf("ListContainerStats failed, error: %v", err)
+			logrus.WithError(err).Error("ListContainerStats failed")
 		} else {
-			glog.V(5).Infof("ListContainerStats returns stats %+v", res.GetStats())
+			log.Tracef("ListContainerStats returns stats %+v", res.GetStats())
 		}
 	}()
 	return in.criContainerdService.ListContainerStats(ctx, r)
 }
 
 func (in *instrumentedService) LoadImage(ctx context.Context, r *api.LoadImageRequest) (res *api.LoadImageResponse, err error) {
-	glog.V(4).Infof("LoadImage from file %q", r.GetFilePath())
+	logrus.Debugf("LoadImage from file %q", r.GetFilePath())
 	defer func() {
 		if err != nil {
-			glog.Errorf("LoadImage failed, error: %v", err)
+			logrus.WithError(err).Error("LoadImage failed")
 		} else {
-			glog.V(4).Infof("LoadImage returns images %+v", res.GetImages())
+			logrus.Debugf("LoadImage returns images %+v", res.GetImages())
 		}
 	}()
 	return in.criContainerdService.LoadImage(ctx, r)

--- a/pkg/server/io/exec_io.go
+++ b/pkg/server/io/exec_io.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 
 	"github.com/containerd/containerd/cio"
-	"github.com/golang/glog"
+	"github.com/sirupsen/logrus"
 
 	cioutil "github.com/containerd/cri-containerd/pkg/ioutil"
 )
@@ -68,13 +68,13 @@ func (e *ExecIO) Attach(opts AttachOptions) <-chan struct{} {
 		wg.Add(1)
 		go func() {
 			if _, err := io.Copy(e.stdin, stdinStreamRC); err != nil {
-				glog.Errorf("Failed to redirect stdin for container exec %q: %v", e.id, err)
+				logrus.WithError(err).Errorf("Failed to redirect stdin for container exec %q", e.id)
 			}
-			glog.V(2).Infof("Container exec %q stdin closed", e.id)
+			logrus.Infof("Container exec %q stdin closed", e.id)
 			if opts.StdinOnce && !opts.Tty {
 				e.stdin.Close()
 				if err := opts.CloseStdin(); err != nil {
-					glog.Errorf("Failed to close stdin for container exec %q: %v", e.id, err)
+					logrus.WithError(err).Errorf("Failed to close stdin for container exec %q", e.id)
 				}
 			} else {
 				if e.stdout != nil {
@@ -90,7 +90,7 @@ func (e *ExecIO) Attach(opts AttachOptions) <-chan struct{} {
 
 	attachOutput := func(t StreamType, stream io.WriteCloser, out io.ReadCloser) {
 		if _, err := io.Copy(stream, out); err != nil {
-			glog.Errorf("Failed to pipe %q for container exec %q: %v", t, e.id, err)
+			logrus.WithError(err).Errorf("Failed to pipe %q for container exec %q", t, e.id)
 		}
 		out.Close()
 		stream.Close()
@@ -99,7 +99,7 @@ func (e *ExecIO) Attach(opts AttachOptions) <-chan struct{} {
 		}
 		e.closer.wg.Done()
 		wg.Done()
-		glog.V(2).Infof("Finish piping %q of container exec %q", t, e.id)
+		logrus.Infof("Finish piping %q of container exec %q", t, e.id)
 	}
 
 	if opts.Stdout != nil {

--- a/pkg/server/sandbox_portforward.go
+++ b/pkg/server/sandbox_portforward.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd"
-	"github.com/golang/glog"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
@@ -83,7 +83,7 @@ func (c *criContainerdService) portForward(id string, port int32, stream io.Read
 		return fmt.Errorf("failed to find nsenter: %v", err)
 	}
 
-	glog.V(2).Infof("Executing port forwarding command: %s %s", nsenter, strings.Join(args, " "))
+	logrus.Infof("Executing port forwarding command: %s %s", nsenter, strings.Join(args, " "))
 
 	cmd := exec.Command(nsenter, args...)
 	cmd.Stdout = stream
@@ -106,17 +106,17 @@ func (c *criContainerdService) portForward(id string, port int32, stream io.Read
 	}
 	go func() {
 		if _, err := io.Copy(in, stream); err != nil {
-			glog.Errorf("Failed to copy port forward input for %q port %d: %v", id, port, err)
+			logrus.WithError(err).Errorf("Failed to copy port forward input for %q port %d", id, port)
 		}
 		in.Close()
-		glog.V(4).Infof("Finish copy port forward input for %q port %d: %v", id, port)
+		logrus.Debugf("Finish copy port forward input for %q port %d: %v", id, port)
 	}()
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("nsenter command returns error: %v, stderr: %q", err, stderr.String())
 	}
 
-	glog.V(2).Infof("Finish port forwarding for %q port %d", id, port)
+	logrus.Infof("Finish port forwarding for %q port %d", id, port)
 
 	return nil
 }

--- a/pkg/server/sandbox_remove.go
+++ b/pkg/server/sandbox_remove.go
@@ -22,10 +22,10 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/docker/docker/pkg/system"
-	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
+	"github.com/containerd/cri-containerd/pkg/log"
 	"github.com/containerd/cri-containerd/pkg/store"
 )
 
@@ -39,7 +39,7 @@ func (c *criContainerdService) RemovePodSandbox(ctx context.Context, r *runtime.
 				r.GetPodSandboxId(), err)
 		}
 		// Do not return error if the id doesn't exist.
-		glog.V(5).Infof("RemovePodSandbox called for sandbox %q that does not exist",
+		log.Tracef("RemovePodSandbox called for sandbox %q that does not exist",
 			r.GetPodSandboxId())
 		return &runtime.RemovePodSandboxResponse{}, nil
 	}
@@ -88,7 +88,7 @@ func (c *criContainerdService) RemovePodSandbox(ctx context.Context, r *runtime.
 		if !errdefs.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to delete sandbox container %q: %v", id, err)
 		}
-		glog.V(5).Infof("Remove called for sandbox container %q that does not exist", id, err)
+		log.Tracef("Remove called for sandbox container %q that does not exist", id)
 	}
 
 	// Remove sandbox from sandbox store. Note that once the sandbox is successfully

--- a/pkg/server/sandbox_status.go
+++ b/pkg/server/sandbox_status.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/golang/glog"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
@@ -160,7 +160,7 @@ func toCRISandboxInfo(ctx context.Context, sandbox sandboxstore.Sandbox,
 	if err == nil {
 		si.RuntimeSpec = spec
 	} else {
-		glog.Errorf("Failed to get sandbox container %q runtime spec: %v", sandbox.ID, err)
+		logrus.WithError(err).Errorf("Failed to get sandbox container %q runtime spec", sandbox.ID)
 	}
 
 	ctrInfo, err := container.Info(ctx)
@@ -172,7 +172,7 @@ func toCRISandboxInfo(ctx context.Context, sandbox sandboxstore.Sandbox,
 		si.SnapshotKey = ctrInfo.SnapshotKey
 		si.Snapshotter = ctrInfo.Snapshotter
 	} else {
-		glog.Errorf("Failed to get sandbox container %q info: %v", sandbox.ID, err)
+		logrus.WithError(err).Errorf("Failed to get sandbox container %q info", sandbox.ID)
 	}
 
 	infoBytes, err := json.Marshal(si)

--- a/pkg/server/sandbox_stop.go
+++ b/pkg/server/sandbox_stop.go
@@ -23,7 +23,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/cri-o/ocicni/pkg/ocicni"
-	"github.com/golang/glog"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
@@ -82,7 +82,7 @@ func (c *criContainerdService) StopPodSandbox(ctx context.Context, r *runtime.St
 		}
 	}
 
-	glog.V(2).Infof("TearDown network for sandbox %q successfully", id)
+	logrus.Infof("TearDown network for sandbox %q successfully", id)
 
 	sandboxRoot := getSandboxRootDir(c.config.RootDir, id)
 	if err := c.unmountSandboxFiles(sandboxRoot, sandbox.Config); err != nil {

--- a/pkg/server/snapshots.go
+++ b/pkg/server/snapshots.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	snapshot "github.com/containerd/containerd/snapshots"
-	"github.com/golang/glog"
+	"github.com/sirupsen/logrus"
 
 	snapshotstore "github.com/containerd/cri-containerd/pkg/store/snapshot"
 )
@@ -59,7 +59,7 @@ func (s *snapshotsSyncer) start() {
 		// check the resource usage and optimize this.
 		for {
 			if err := s.sync(); err != nil {
-				glog.Errorf("Failed to sync snapshot stats: %v", err)
+				logrus.WithError(err).Error("Failed to sync snapshot stats")
 			}
 			<-tick.C
 		}
@@ -99,7 +99,7 @@ func (s *snapshotsSyncer) sync() error {
 		usage, err := s.snapshotter.Usage(context.Background(), info.Name)
 		if err != nil {
 			if !errdefs.IsNotFound(err) {
-				glog.Errorf("Failed to get usage for snapshot %q: %v", info.Name, err)
+				logrus.WithError(err).Errorf("Failed to get usage for snapshot %q", info.Name)
 			}
 			continue
 		}

--- a/test/e2e_node/init.yaml
+++ b/test/e2e_node/init.yaml
@@ -79,7 +79,7 @@ write_files:
       LimitNPROC=infinity
       LimitCORE=infinity
       ExecStart=/home/cri-containerd/usr/local/bin/cri-containerd \
-        --logtostderr --v=4 \
+        --log-level=debug \
         --network-bin-dir=/home/cri-containerd/opt/cni/bin \
         --network-conf-dir=/home/cri-containerd/etc/cni/net.d
 


### PR DESCRIPTION
Use `logrus` instead of `glog` to make `cri-containerd` log output consistent with `containerd`.

The log level mapping:
1) glog.Error[f] => logrus.Error[f]
2) glog.Warning[f] => logrus.Warn[f]
3) glog.V(0/2).Info[f] => logrus.Info[f]
4) glog.V(4).Info[f] => logrus.Debug[f]
5) glog.V(5).Info[f] => log.Trace[f]. logrus doesn't support `trace` level, we added a util package `pkg/log` to do that. https://github.com/sirupsen/logrus/issues/663

Note that instead of `": %v", err`, we'll use `logrus.WithError(err)` in the future.

@mikebrow @abhi @yanxuean @miaoyq 