### PR TITLE
Use containerd grpc server

### DIFF
--- a/cmd/cri-containerd/cri_containerd.go
+++ b/cmd/cri-containerd/cri_containerd.go
@@ -110,8 +110,8 @@ func main() {
 		// Pass in non-empty final function to avoid os.Exit(1). We expect `Run`
 		// to return itself.
 		h := interrupt.New(func(os.Signal) {}, s.Stop)
-		if err := h.Run(func() error { return s.Run() }); err != nil {
-			return fmt.Errorf("failed to run cri-containerd grpc server: %v", err)
+		if err := h.Run(func() error { return s.Run(true) }); err != nil {
+			return fmt.Errorf("failed to run cri-containerd with grpc server: %v", err)
 		}
 		return nil
 	}

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -31,7 +31,10 @@ test_setup ${REPORT_DIR}
 # Run integration test.
 # Set STANDALONE_CRI_CONTAINERD so that integration test can see it.
 # Some integration test needs the env to skip itself.
-sudo STANDALONE_CRI_CONTAINERD=${STANDALONE_CRI_CONTAINERD} ${ROOT}/_output/integration.test --test.run="${FOCUS}" --test.v
+sudo ${ROOT}/_output/integration.test --test.run="${FOCUS}" --test.v \
+  --standalone-cri-containerd=${STANDALONE_CRI_CONTAINERD} \
+  --cri-containerd-endpoint=${CRICONTAINERD_SOCK}
+
 test_exit_code=$?
 
 test_teardown

--- a/hack/test-utils.sh
+++ b/hack/test-utils.sh
@@ -25,6 +25,9 @@ RESTART_WAIT_PERIOD=${RESTART_WAIT_PERIOD:-10}
 STANDALONE_CRI_CONTAINERD=${STANDALONE_CRI_CONTAINERD:-true}
 
 CRICONTAINERD_SOCK=/var/run/cri-containerd.sock
+if ! ${STANDALONE_CRI_CONTAINERD}; then
+  CRICONTAINERD_SOCK=/var/run/containerd/containerd.sock
+fi
 
 cri_containerd_pid=
 containerd_pid=

--- a/integration/restart_test.go
+++ b/integration/restart_test.go
@@ -34,7 +34,7 @@ import (
 // NOTE(random-liu): Current restart test only support standalone cri-containerd mode.
 
 func TestSandboxAcrossCRIContainerdRestart(t *testing.T) {
-	if os.Getenv(standaloneEnvKey) == "false" {
+	if !*standaloneCRIContainerd {
 		t.Skip("Skip because cri-containerd does not run in standalone mode")
 	}
 	ctx := context.Background()
@@ -153,7 +153,7 @@ func TestSandboxAcrossCRIContainerdRestart(t *testing.T) {
 // teardown the network properly.
 // This test uses host network sandbox to avoid resource leakage.
 func TestSandboxDeletionAcrossCRIContainerdRestart(t *testing.T) {
-	if os.Getenv(standaloneEnvKey) == "false" {
+	if !*standaloneCRIContainerd {
 		t.Skip("Skip because cri-containerd does not run in standalone mode")
 	}
 	ctx := context.Background()

--- a/pkg/atomic/atomic_boolean.go
+++ b/pkg/atomic/atomic_boolean.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 The Containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package atomic
+
+import "sync/atomic"
+
+// Bool is an atomic Boolean,
+// Its methods are all atomic, thus safe to be called by
+// multiple goroutines simultaneously.
+type Bool interface {
+	Set()
+	Unset()
+	IsSet() bool
+}
+
+// NewBool creates an Bool with given default value
+func NewBool(ok bool) Bool {
+	ab := new(atomicBool)
+	if ok {
+		ab.Set()
+	}
+	return ab
+}
+
+type atomicBool int32
+
+// Set sets the Boolean to true
+func (ab *atomicBool) Set() {
+	atomic.StoreInt32((*int32)(ab), 1)
+}
+
+// Unset sets the Boolean to false
+func (ab *atomicBool) Unset() {
+	atomic.StoreInt32((*int32)(ab), 0)
+}
+
+// IsSet returns whether the Boolean is true
+func (ab *atomicBool) IsSet() bool {
+	return atomic.LoadInt32((*int32)(ab)) == 1
+}

--- a/pkg/atomic/atomic_boolean_test.go
+++ b/pkg/atomic/atomic_boolean_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2018 The Containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package atomic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBoolean(t *testing.T) {
+	ab := NewBool(true)
+	assert.True(t, ab.IsSet())
+	ab.Unset()
+	assert.False(t, ab.IsSet())
+	ab.Set()
+	assert.True(t, ab.IsSet())
+}

--- a/pkg/server/version.go
+++ b/pkg/server/version.go
@@ -36,6 +36,7 @@ const (
 )
 
 // Version returns the runtime name, runtime version and runtime API version.
+// TODO(random-liu): Return containerd version since we are going to merge 2 daemons.
 func (c *criContainerdService) Version(ctx context.Context, r *runtime.VersionRequest) (*runtime.VersionResponse, error) {
 	return &runtime.VersionResponse{
 		Version:        kubeAPIVersion,


### PR DESCRIPTION
Let CRI plugin use containerd grpc server.

Previously we had a circular dependency problem:
1) cri plugin becomes one of containerd grpc service.
2) cri plugin itself replies on containerd grpc services to do initialization.

This PR split the CRI GRPC service creation and initialization.
During plugin regstration, cri plugin will:
1) Create the grpc service with `Register` method and return to containerd;
2) Start a goroutine to do initialization asynchronously.
3) All GRPC service request handlers need to return error before initialization is finished.

In this way, we can make cri one of containerd grpc services, and make sure CRI only starts serving request when initialization is done.

The only downside is that after containerd starts, CRI might not be available immediately.
However, we should never assume that grpc service starts serving when containerd process is started. And kubelet can tolerant that.

/cc @containerd/containerd-maintainers 