### PR TITLE
hack/versions: extract most from vendor.conf

### DIFF
--- a/hack/test-e2e-node.sh
+++ b/hack/test-e2e-node.sh
@@ -59,12 +59,11 @@ fi
 GOPATH=${GOPATH%%:*}
 
 # Get kubernetes
-KUBERNETES_REPO="https://github.com/kubernetes/kubernetes"
 KUBERNETES_PATH="${GOPATH}/src/k8s.io/kubernetes"
 if [ ! -d "${KUBERNETES_PATH}" ]; then
   mkdir -p ${KUBERNETES_PATH}
   cd ${KUBERNETES_PATH}
-  git clone ${KUBERNETES_REPO} .
+  git clone https://${KUBERNETES_REPO} .
 fi
 cd ${KUBERNETES_PATH}
 git fetch --all

--- a/hack/update-vendor.sh
+++ b/hack/update-vendor.sh
@@ -21,47 +21,11 @@ set -o pipefail
 source $(dirname "${BASH_SOURCE[0]}")/utils.sh
 cd ${ROOT}
 
-update_hack_versions() {
-  need_update=false
-  declare -A map=()
-  map["RUNC_VERSION"]="github.com/opencontainers/runc"
-  map["CNI_VERSION"]="github.com/containernetworking/cni"
-  map["CONTAINERD_VERSION"]="github.com/containerd/containerd"
-  map["KUBERNETES_VERSION"]="k8s.io/kubernetes"
-  for key in ${!map[@]}
-  do
-    vendor_commitid=$(grep ${map[${key}]} vendor.conf | awk '{print $2}')
-    version_commitid=$(grep ${key} hack/versions | awk -F "=" '{print $2}')
-    if [ ${vendor_commitid} != ${version_commitid} ]; then
-      if [ $# -gt 0 ] && [ ${1} = "-only-verify" ]; then
-	need_update=true
-	echo "Need to update the value of ${key} from ${version_commitid} to ${vendor_commitid}."
-      else
-	echo "Updating the value of ${key} from ${version_commitid} to ${vendor_commitid}."
-	sed -i "s/\b${version_commitid}$/${vendor_commitid}/g" hack/versions
-      fi
-    fi
-  done
-
-  if [ ${need_update} = true ]; then
-    echo "Please update \"hack/versions\" by executing \"hack/update-vendor.sh\"!"
-    exit 1
-  fi
-}
-
-echo "Compare vendor with hack/versions..."
-update_hack_versions
-
 # hack/versions should be correct now.
 echo "Compare vendor with containerd vendors..."
 source hack/versions
-if [ -z "${CONTAINERD_REPO}" ]; then
-  CONTAINERD_REPO=containerd/containerd
-else
-  CONTAINERD_REPO=${CONTAINERD_REPO#*/}
-fi
 containerd_vendor=$(mktemp /tmp/containerd-vendor.conf.XXXX)
-curl -s https://raw.githubusercontent.com/${CONTAINERD_REPO}/${CONTAINERD_VERSION}/vendor.conf > ${containerd_vendor}
+curl -s https://raw.githubusercontent.com/${CONTAINERD_REPO#*/}/${CONTAINERD_VERSION}/vendor.conf > ${containerd_vendor}
 # Create a temporary vendor file to update.
 tmp_vendor=$(mktemp /tmp/vendor.conf.XXXX)
 while read vendor; do
@@ -94,9 +58,6 @@ if ! diff vendor.conf ${tmp_vendor} > /dev/null; then
   fi
 fi
 rm ${containerd_vendor}
-
-echo "Compare new vendor with hack/versions..."
-update_hack_versions
 
 echo "Sort vendor.conf..."
 sort vendor.conf -o vendor.conf

--- a/hack/versions
+++ b/hack/versions
@@ -1,6 +1,14 @@
-RUNC_VERSION=9f9c96235cc97674e935002fc3d78361b696a69e
-CNI_VERSION=v0.6.0
-CONTAINERD_VERSION=f12ba2407e328c98f8be5eacbb9c510b073dd4c0
-CONTAINERD_REPO=
+from-vendor RUNC       github.com/opencontainers/runc
+from-vendor CNI        github.com/containernetworking/plugins
+from-vendor CONTAINERD github.com/containerd/containerd
+from-vendor KUBERNETES k8s.io/kubernetes
+
+# k8s.io is actually a redirect, but we do not handle the go-import
+# metadata which `go get` and `vndr` etc do. Handle it manually here.
+if [ x"$KUBERNETES_REPO" = "xk8s.io" ] ; then
+    KUBERNETES_REPO="https://github.com/kubernetes/kubernetes"
+fi
+
+# Not from vendor.conf.
 CRITOOL_VERSION=240a840375cdabb5860c75c99e8b0d0a776006b4
-KUBERNETES_VERSION=0caa20c65f147e15f5545862510eb7e81c42b0a3
+CRITOOL_REPO=github.com/kubernetes-incubator/cri-tools


### PR DESCRIPTION
This sets `$what_VERSION` and `$what_REPO` for runc, cni, containerd and
kubernetes based on vendor.conf, removing the need to duplicate things in
hack/versions.

With this `update_hack_versions` becomes redundant so remove it and both calls.

Since CONTAINERD_REPO is now unconditionally set we can also simplify the
fetching of vendor.conf in update-vendor.sh a bit, so do so. Further since
`*_REPO` are now unconditionally set we can support alternative clone paths for
all of these repos by adjusting checkout_repo to make the 3rd argument
non-optional and always passing it. Since `CRITOOL_VERSION` is not coming from
`vendor.conf` (since it is not used from Go code) we manually set
`CRITOOL_REPO` for consistency.

The final wrinkle is that `k8s.io/kubernetes` is has a Go specific redirect in
the form of HTML meta headers returned from https://k8s.io/kubernetes/?go-get=1
which point to the real repo to clone. Parsing that in shell is tricky so just
hardcode that.

Fixes #540.

Signed-off-by: Ian Campbell <ijc@docker.com>

/cc @mikebrow 