### PR TITLE
Use containerd config

### DIFF
--- a/cmd/cri-containerd/cri_containerd.go
+++ b/cmd/cri-containerd/cri_containerd.go
@@ -30,7 +30,6 @@ import (
 	"github.com/containerd/cgroups"
 	"github.com/containerd/containerd/sys"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/util/interrupt"
@@ -90,7 +89,6 @@ func main() {
 		if err := o.InitFlags(cmd.Flags()); err != nil {
 			return fmt.Errorf("failed to init CRI containerd flags: %v", err)
 		}
-		validateConfig(o)
 
 		if err := setLogLevel(o.LogLevel); err != nil {
 			return fmt.Errorf("failed to set log level: %v", err)
@@ -118,7 +116,7 @@ func main() {
 		}
 
 		logrus.Infof("Run cri-containerd grpc server on socket %q", o.SocketPath)
-		s, err := server.NewCRIContainerdService(o.Config)
+		s, err := server.NewCRIContainerdService(o.CRIConfig)
 		if err != nil {
 			return fmt.Errorf("failed to create CRI containerd service: %v", err)
 		}
@@ -135,16 +133,6 @@ func main() {
 	if err := cmd.Execute(); err != nil {
 		// Error should have been reported.
 		os.Exit(1)
-	}
-}
-
-func validateConfig(o *options.CRIContainerdOptions) {
-	if o.EnableSelinux {
-		if !selinux.GetEnabled() {
-			logrus.Warn("Selinux is not supported")
-		}
-	} else {
-		selinux.SetDisabled()
 	}
 }
 

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -25,6 +25,11 @@ FOCUS=${FOCUS:-""}
 # REPORT_DIR is the the directory to store test logs.
 REPORT_DIR=${REPORT_DIR:-"/tmp/test-integration"}
 
+CRICONTAINERD_ROOT="/var/lib/cri-containerd"
+if ! ${STANDALONE_CRI_CONTAINERD}; then
+  CRICONTAINERD_ROOT="/var/lib/containerd/io.containerd.grpc.v1.cri"
+fi
+
 mkdir -p ${REPORT_DIR}
 test_setup ${REPORT_DIR}
 
@@ -33,7 +38,8 @@ test_setup ${REPORT_DIR}
 # Some integration test needs the env to skip itself.
 sudo ${ROOT}/_output/integration.test --test.run="${FOCUS}" --test.v \
   --standalone-cri-containerd=${STANDALONE_CRI_CONTAINERD} \
-  --cri-containerd-endpoint=${CRICONTAINERD_SOCK}
+  --cri-containerd-endpoint=${CRICONTAINERD_SOCK} \
+  --cri-containerd-root=${CRICONTAINERD_ROOT}
 
 test_exit_code=$?
 

--- a/integration/restart_test.go
+++ b/integration/restart_test.go
@@ -201,7 +201,7 @@ func TestSandboxDeletionAcrossCRIContainerdRestart(t *testing.T) {
 	assert.Empty(t, loadedSandboxes)
 
 	t.Logf("Make sure sandbox root is removed")
-	sandboxRoot := filepath.Join(criContainerdRoot, "sandboxes", sb)
+	sandboxRoot := filepath.Join(*criContainerdRoot, "sandboxes", sb)
 	_, err = os.Stat(sandboxRoot)
 	assert.True(t, os.IsNotExist(err))
 }

--- a/integration/test_utils.go
+++ b/integration/test_utils.go
@@ -39,7 +39,6 @@ const (
 	pauseImage         = "gcr.io/google_containers/pause:3.0" // This is the same with default sandbox image.
 	k8sNamespace       = "k8s.io"                             // This is the same with server.k8sContainerdNamespace.
 	containerdEndpoint = "/run/containerd/containerd.sock"
-	criContainerdRoot  = "/var/lib/cri-containerd"
 )
 
 var (
@@ -51,6 +50,7 @@ var (
 
 var standaloneCRIContainerd = flag.Bool("standalone-cri-containerd", true, "Whether cri-containerd is running in standalone mode.")
 var criContainerdEndpoint = flag.String("cri-containerd-endpoint", "/var/run/cri-containerd.sock", "The endpoint of cri-containerd.")
+var criContainerdRoot = flag.String("cri-containerd-root", "/var/lib/cri-containerd", "The root directory of cri-containerd.")
 
 func init() {
 	flag.Parse()

--- a/integration/volume_copy_up_test.go
+++ b/integration/volume_copy_up_test.go
@@ -70,7 +70,7 @@ func TestVolumeCopyUp(t *testing.T) {
 	assert.Equal(t, "test_content\n", string(stdout))
 
 	t.Logf("Check host path of the volume")
-	hostCmd := fmt.Sprintf("ls %s/containers/%s/volumes/*/test_file | xargs cat", criContainerdRoot, cn)
+	hostCmd := fmt.Sprintf("ls %s/containers/%s/volumes/*/test_file | xargs cat", *criContainerdRoot, cn)
 	output, err := exec.Command("sh", "-c", hostCmd).CombinedOutput()
 	require.NoError(t, err)
 	assert.Equal(t, "test_content\n", string(output))

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -39,9 +39,11 @@ const (
 // newTestCRIContainerdService creates a fake criContainerdService for test.
 func newTestCRIContainerdService() *criContainerdService {
 	return &criContainerdService{
-		config: options.Config{
-			RootDir:      testRootDir,
-			SandboxImage: testSandboxImage,
+		config: options.CRIConfig{
+			RootDir: testRootDir,
+			PluginConfig: options.PluginConfig{
+				SandboxImage: testSandboxImage,
+			},
 		},
 		imageFSUUID:        testImageFSUUID,
 		os:                 ostesting.NewFakeOS(),


### PR DESCRIPTION
Based on https://github.com/containerd/cri-containerd/pull/555.

Use containerd plugin config. With this PR, we can use contianerd config file to config CRI plugin:
```console
$ cat /etc/containerd/config.toml 
[plugins.linux]
  shim_debug = true
[plugins.cri]
  stream_server_port = "10010"
```
