### PR TITLE
Avoid containerd access as much as possible.

### DIFF
--- a/pkg/server/container_list_test.go
+++ b/pkg/server/container_list_test.go
@@ -170,20 +170,26 @@ func (c containerForTest) toContainer() (containerstore.Container, error) {
 func TestListContainers(t *testing.T) {
 	c := newTestCRIContainerdService()
 	sandboxesInStore := []sandboxstore.Sandbox{
-		{
-			Metadata: sandboxstore.Metadata{
+		sandboxstore.NewSandbox(
+			sandboxstore.Metadata{
 				ID:     "s-1abcdef1234",
 				Name:   "sandboxname-1",
 				Config: &runtime.PodSandboxConfig{Metadata: &runtime.PodSandboxMetadata{Name: "podname-1"}},
 			},
-		},
-		{
-			Metadata: sandboxstore.Metadata{
+			sandboxstore.Status{
+				State: sandboxstore.StateReady,
+			},
+		),
+		sandboxstore.NewSandbox(
+			sandboxstore.Metadata{
 				ID:     "s-2abcdef1234",
 				Name:   "sandboxname-2",
 				Config: &runtime.PodSandboxConfig{Metadata: &runtime.PodSandboxMetadata{Name: "podname-2"}},
 			},
-		},
+			sandboxstore.Status{
+				State: sandboxstore.StateNotReady,
+			},
+		),
 	}
 	createdAt := time.Now().UnixNano()
 	startedAt := time.Now().UnixNano()

--- a/pkg/server/container_status.go
+++ b/pkg/server/container_status.go
@@ -111,6 +111,7 @@ type containerInfo struct {
 }
 
 // toCRIContainerInfo converts internal container object information to CRI container status response info map.
+// TODO(random-liu): Return error instead of logging.
 func toCRIContainerInfo(ctx context.Context, container containerstore.Container, verbose bool) (map[string]string, error) {
 	if !verbose {
 		return nil, nil

--- a/pkg/server/container_stop.go
+++ b/pkg/server/container_stop.go
@@ -31,11 +31,9 @@ import (
 	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
 )
 
-const (
-	// killContainerTimeout is the timeout that we wait for the container to
-	// be SIGKILLed.
-	killContainerTimeout = 2 * time.Minute
-)
+// killContainerTimeout is the timeout that we wait for the container to
+// be SIGKILLed.
+const killContainerTimeout = 2 * time.Minute
 
 // StopContainer stops a running container with a grace period (i.e., timeout).
 func (c *criContainerdService) StopContainer(ctx context.Context, r *runtime.StopContainerRequest) (*runtime.StopContainerResponse, error) {

--- a/pkg/server/sandbox_stop_test.go
+++ b/pkg/server/sandbox_stop_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2018 The Containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+
+	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
+)
+
+func TestWaitSandboxStop(t *testing.T) {
+	id := "test-id"
+	for desc, test := range map[string]struct {
+		state     sandboxstore.State
+		cancel    bool
+		timeout   time.Duration
+		expectErr bool
+	}{
+		"should return error if timeout exceeds": {
+			state:     sandboxstore.StateReady,
+			timeout:   2 * stopCheckPollInterval,
+			expectErr: true,
+		},
+		"should return error if context is cancelled": {
+			state:     sandboxstore.StateReady,
+			timeout:   time.Hour,
+			cancel:    true,
+			expectErr: true,
+		},
+		"should not return error if sandbox is stopped before timeout": {
+			state:     sandboxstore.StateNotReady,
+			timeout:   time.Hour,
+			expectErr: false,
+		},
+	} {
+		c := newTestCRIContainerdService()
+		sandbox := sandboxstore.NewSandbox(
+			sandboxstore.Metadata{ID: id},
+			sandboxstore.Status{State: test.state},
+		)
+		ctx := context.Background()
+		if test.cancel {
+			cancelledCtx, cancel := context.WithCancel(ctx)
+			cancel()
+			ctx = cancelledCtx
+		}
+		err := c.waitSandboxStop(ctx, sandbox, test.timeout)
+		assert.Equal(t, test.expectErr, err != nil, desc)
+	}
+}

--- a/pkg/store/container/status.go
+++ b/pkg/store/container/status.go
@@ -119,8 +119,6 @@ type StatusStorage interface {
 	Delete() error
 }
 
-// TODO(random-liu): Add factory function and configure checkpoint path.
-
 // StoreStatus creates the storage containing the passed in container status with the
 // specified id.
 // The status MUST be created in one transaction.

--- a/pkg/store/sandbox/metadata.go
+++ b/pkg/store/sandbox/metadata.go
@@ -52,6 +52,8 @@ type Metadata struct {
 	Config *runtime.PodSandboxConfig
 	// NetNSPath is the network namespace used by the sandbox.
 	NetNSPath string
+	// IP of Pod if it is attached to non host network
+	IP string
 }
 
 // MarshalJSON encodes Metadata into bytes in json format.

--- a/pkg/store/sandbox/status.go
+++ b/pkg/store/sandbox/status.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2018 The Containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandbox
+
+import (
+	"sync"
+	"time"
+)
+
+// State is the sandbox state we use in cri-containerd.
+// It has unknown state defined.
+type State uint32
+
+const (
+	// StateUnknown is unknown state of sandbox. Sandbox
+	// is in unknown state before its corresponding sandbox container
+	// is created. Sandbox in unknown state should be ignored by most
+	// functions, unless the caller needs to update sandbox state.
+	StateUnknown State = iota
+	// StateReady is ready state, it means sandbox container
+	// is running.
+	StateReady
+	// StateNotReady is notready state, it ONLY means sandbox
+	// container is not running.
+	// StopPodSandbox should still be called for NOTREADY sandbox to
+	// cleanup resources other than sandbox container, e.g. network namespace.
+	// This is an assumption made in CRI.
+	StateNotReady
+)
+
+// Status is the status of a sandbox.
+type Status struct {
+	// Pid is the init process id of the sandbox container.
+	Pid uint32
+	// CreatedAt is the created timestamp.
+	CreatedAt time.Time
+	// State is the state of the sandbox.
+	State State
+}
+
+// UpdateFunc is function used to update the sandbox status. If there
+// is an error, the update will be rolled back.
+type UpdateFunc func(Status) (Status, error)
+
+// StatusStorage manages the sandbox status.
+// The status storage for sandbox is different from container status storage,
+// because we don't checkpoint sandbox status. If we need checkpoint in the
+// future, we should combine this with container status storage.
+type StatusStorage interface {
+	// Get a sandbox status.
+	Get() Status
+	// Update the sandbox status. Note that the update MUST be applied
+	// in one transaction.
+	Update(UpdateFunc) error
+}
+
+// StoreStatus creates the storage containing the passed in sandbox status with the
+// specified id.
+// The status MUST be created in one transaction.
+func StoreStatus(status Status) StatusStorage {
+	return &statusStorage{status: status}
+}
+
+type statusStorage struct {
+	sync.RWMutex
+	status Status
+}
+
+// Get a copy of sandbox status.
+func (s *statusStorage) Get() Status {
+	s.RLock()
+	defer s.RUnlock()
+	return s.status
+}
+
+// Update the sandbox status.
+func (s *statusStorage) Update(u UpdateFunc) error {
+	s.Lock()
+	defer s.Unlock()
+	newStatus, err := u(s.status)
+	if err != nil {
+		return err
+	}
+	s.status = newStatus
+	return nil
+}

--- a/pkg/store/sandbox/status_test.go
+++ b/pkg/store/sandbox/status_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandbox
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	assertlib "github.com/stretchr/testify/assert"
+)
+
+func TestStatus(t *testing.T) {
+	testStatus := Status{
+		Pid:       123,
+		CreatedAt: time.Now(),
+		State:     StateUnknown,
+	}
+	updateStatus := Status{
+		Pid:       456,
+		CreatedAt: time.Now(),
+		State:     StateReady,
+	}
+	updateErr := errors.New("update error")
+	assert := assertlib.New(t)
+
+	t.Logf("simple store and get")
+	s := StoreStatus(testStatus)
+	old := s.Get()
+	assert.Equal(testStatus, old)
+
+	t.Logf("failed update should not take effect")
+	err := s.Update(func(o Status) (Status, error) {
+		o = updateStatus
+		return o, updateErr
+	})
+	assert.Equal(updateErr, err)
+	assert.Equal(testStatus, s.Get())
+
+	t.Logf("successful update should take effect but not checkpoint")
+	err = s.Update(func(o Status) (Status, error) {
+		o = updateStatus
+		return o, nil
+	})
+	assert.NoError(err)
+	assert.Equal(updateStatus, s.Get())
+}


### PR DESCRIPTION
Related to https://github.com/containerd/containerd/issues/2020.

This PR:
1) Cache sandbox status in sandbox store.
2) Update sandbox status based on containerd event.
3) Recover sandbox cache during restart.

This should reduce the containerd/containerd-shim cpu/memory usage.

Signed-off-by: Lantao Liu <lantaol@google.com>