### PR TITLE
Add runtime cgroup and fix a cli panic.

### DIFF
--- a/cluster/gce/cloud-init/master.yaml
+++ b/cluster/gce/cloud-init/master.yaml
@@ -31,6 +31,9 @@ write_files:
       # installed by cloud-init
       oom_score = -999
 
+      [cgroup]
+        path = "/runtime"
+
       [plugins.linux]
         shim = "/home/cri-containerd/usr/local/bin/containerd-shim"
         runtime = "/home/cri-containerd/usr/local/sbin/runc"
@@ -84,7 +87,8 @@ write_files:
       ExecStart=/home/cri-containerd/usr/local/bin/cri-containerd \
         --log-level=debug \
         --network-bin-dir=/home/cri-containerd/opt/cni/bin \
-        --network-conf-dir=/home/cri-containerd/etc/cni/net.d
+        --network-conf-dir=/home/cri-containerd/etc/cni/net.d \
+        --cgroup-path=/runtime
 
       [Install]
       WantedBy=cri-containerd.target

--- a/cluster/gce/cloud-init/node.yaml
+++ b/cluster/gce/cloud-init/node.yaml
@@ -34,6 +34,9 @@ write_files:
       # installed by cloud-init
       oom_score = -999
 
+      [cgroup]
+        path = "/runtime"
+
       [plugins.linux]
         shim = "/home/cri-containerd/usr/local/bin/containerd-shim"
         runtime = "/home/cri-containerd/usr/local/sbin/runc"
@@ -87,7 +90,8 @@ write_files:
       ExecStart=/home/cri-containerd/usr/local/bin/cri-containerd \
         --log-level=debug \
         --network-bin-dir=/home/kubernetes/bin \
-        --network-conf-dir=/etc/cni/net.d
+        --network-conf-dir=/etc/cni/net.d \
+        --cgroup-path=/runtime
 
       [Install]
       WantedBy=cri-containerd.target

--- a/cmd/cri-containerd/cri_containerd.go
+++ b/cmd/cri-containerd/cri_containerd.go
@@ -116,7 +116,7 @@ func main() {
 		}
 
 		logrus.Infof("Run cri-containerd grpc server on socket %q", o.SocketPath)
-		s, err := server.NewCRIContainerdService(o.CRIConfig)
+		s, err := server.NewCRIContainerdService(o.Config)
 		if err != nil {
 			return fmt.Errorf("failed to create CRI containerd service: %v", err)
 		}

--- a/cmd/cri-containerd/options/options.go
+++ b/cmd/cri-containerd/options/options.go
@@ -66,7 +66,7 @@ type CniConfig struct {
 }
 
 // PluginConfig contains toml config related to CRI plugin,
-// it is a subset of CRIConfig.
+// it is a subset of Config.
 type PluginConfig struct {
 	// ContainerdConfig contains config related to containerd
 	ContainerdConfig `toml:"containerd" json:"containerd,omitempty"`
@@ -92,10 +92,10 @@ type PluginConfig struct {
 	EnableIPv6DAD bool `toml:"enable_ipv6_dad" json:"enableIPv6DAD,omitempty"`
 }
 
-// CRIConfig contains toml config related to CRI service.
+// Config contains toml config related cri-containerd daemon.
 // TODO(random-liu): Make this an internal config object when we no longer support cri-containerd
 // standalone mode. At that time, we can clean this up.
-type CRIConfig struct {
+type Config struct {
 	// PluginConfig is the config for CRI plugin.
 	PluginConfig
 	// ContainerdRootDir is the root directory path for containerd.
@@ -109,23 +109,20 @@ type CRIConfig struct {
 	// RootDir is the root directory path for managing cri-containerd files
 	// (metadata checkpoint etc.)
 	RootDir string `toml:"root_dir" json:"rootDir,omitempty"`
-}
-
-// Config contains toml config related cri-containerd daemon.
-type Config struct {
-	CRIConfig `toml:"-"`
+	// TODO(random-liu): Remove following fields when we no longer support cri-containerd
+	// standalone mode.
 	// CgroupPath is the path for the cgroup that cri-containerd is placed in.
-	CgroupPath string `toml:"cgroup_path"`
+	CgroupPath string `toml:"cgroup_path" json:"cgroupPath,omitempty"`
 	// OOMScore adjust the cri-containerd's oom score
-	OOMScore int `toml:"oom_score"`
+	OOMScore int `toml:"oom_score" json:"oomScore,omitempty"`
 	// EnableProfiling is used for enable profiling via host:port/debug/pprof/
-	EnableProfiling bool `toml:"profiling"`
+	EnableProfiling bool `toml:"profiling" json:"enableProfiling,omitempty"`
 	// ProfilingPort is the port for profiling via host:port/debug/pprof/
-	ProfilingPort string `toml:"profiling_port"`
+	ProfilingPort string `toml:"profiling_port" json:"profilingPort,omitempty"`
 	// ProfilingAddress is address for profiling via host:port/debug/pprof/
-	ProfilingAddress string `toml:"profiling_addr"`
+	ProfilingAddress string `toml:"profiling_addr" json:"profilingAddress,omitempty"`
 	// LogLevel is the logrus log level.
-	LogLevel string `toml:"log_level"`
+	LogLevel string `toml:"log_level" json:"logLevel,omitempty"`
 }
 
 // CRIContainerdOptions contains cri-containerd command line and toml options.
@@ -243,37 +240,35 @@ func AddGRPCFlags(fs *pflag.FlagSet) (*string, *time.Duration) {
 // DefaultConfig returns default configurations of cri-containerd.
 func DefaultConfig() Config {
 	return Config{
-		CRIConfig: CRIConfig{
-			PluginConfig: PluginConfig{
-				CniConfig: CniConfig{
-					NetworkPluginBinDir:  "/opt/cni/bin",
-					NetworkPluginConfDir: "/etc/cni/net.d",
-				},
-				ContainerdConfig: ContainerdConfig{
-					Snapshotter:   containerd.DefaultSnapshotter,
-					Runtime:       "io.containerd.runtime.v1.linux",
-					RuntimeEngine: "",
-					RuntimeRoot:   "",
-				},
-				StreamServerAddress: "",
-				StreamServerPort:    "10010",
-				EnableSelinux:       false,
-				SandboxImage:        "gcr.io/google_containers/pause:3.0",
-				StatsCollectPeriod:  10,
-				SystemdCgroup:       false,
-				SkipImageFSUUID:     false,
-				EnableIPv6DAD:       false,
+		PluginConfig: PluginConfig{
+			CniConfig: CniConfig{
+				NetworkPluginBinDir:  "/opt/cni/bin",
+				NetworkPluginConfDir: "/etc/cni/net.d",
 			},
-			ContainerdRootDir:  "/var/lib/containerd",
-			ContainerdEndpoint: "/run/containerd/containerd.sock",
-			SocketPath:         "/var/run/cri-containerd.sock",
-			RootDir:            "/var/lib/cri-containerd",
+			ContainerdConfig: ContainerdConfig{
+				Snapshotter:   containerd.DefaultSnapshotter,
+				Runtime:       "io.containerd.runtime.v1.linux",
+				RuntimeEngine: "",
+				RuntimeRoot:   "",
+			},
+			StreamServerAddress: "",
+			StreamServerPort:    "10010",
+			EnableSelinux:       false,
+			SandboxImage:        "gcr.io/google_containers/pause:3.0",
+			StatsCollectPeriod:  10,
+			SystemdCgroup:       false,
+			SkipImageFSUUID:     false,
+			EnableIPv6DAD:       false,
 		},
-		CgroupPath:       "",
-		OOMScore:         -999,
-		EnableProfiling:  true,
-		ProfilingPort:    "10011",
-		ProfilingAddress: "127.0.0.1",
-		LogLevel:         "info",
+		ContainerdRootDir:  "/var/lib/containerd",
+		ContainerdEndpoint: "/run/containerd/containerd.sock",
+		SocketPath:         "/var/run/cri-containerd.sock",
+		RootDir:            "/var/lib/cri-containerd",
+		CgroupPath:         "",
+		OOMScore:           -999,
+		EnableProfiling:    true,
+		ProfilingPort:      "10011",
+		ProfilingAddress:   "127.0.0.1",
+		LogLevel:           "info",
 	}
 }

--- a/cri.go
+++ b/cri.go
@@ -52,7 +52,7 @@ func init() {
 func initCRIService(ic *plugin.InitContext) (interface{}, error) {
 	ctx := ic.Context
 	pluginConfig := ic.Config.(*options.PluginConfig)
-	c := options.CRIConfig{
+	c := options.Config{
 		PluginConfig: *pluginConfig,
 		// This is a hack. We assume that containerd root directory
 		// is one level above plugin directory.

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -75,7 +75,7 @@ type CRIContainerdService interface {
 // criContainerdService implements CRIContainerdService.
 type criContainerdService struct {
 	// config contains all configurations.
-	config options.CRIConfig
+	config options.Config
 	// imageFSUUID is the device uuid of image filesystem.
 	imageFSUUID string
 	// apparmorEnabled indicates whether apparmor is enabled.
@@ -114,7 +114,7 @@ type criContainerdService struct {
 }
 
 // NewCRIContainerdService returns a new instance of CRIContainerdService
-func NewCRIContainerdService(config options.CRIConfig) (CRIContainerdService, error) {
+func NewCRIContainerdService(config options.Config) (CRIContainerdService, error) {
 	var err error
 	c := &criContainerdService{
 		config:             config,

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -39,7 +39,7 @@ const (
 // newTestCRIContainerdService creates a fake criContainerdService for test.
 func newTestCRIContainerdService() *criContainerdService {
 	return &criContainerdService{
-		config: options.CRIConfig{
+		config: options.Config{
 			RootDir: testRootDir,
 			PluginConfig: options.PluginConfig{
 				SandboxImage: testSandboxImage,

--- a/test/e2e_node/init.yaml
+++ b/test/e2e_node/init.yaml
@@ -30,6 +30,9 @@ write_files:
       # installed by cloud-init
       oom_score = -999
 
+      [cgroup]
+        path = "/runtime"
+
       [plugins.linux]
         shim = "/home/cri-containerd/usr/local/bin/containerd-shim"
         runtime = "/home/cri-containerd/usr/local/sbin/runc"
@@ -81,7 +84,8 @@ write_files:
       ExecStart=/home/cri-containerd/usr/local/bin/cri-containerd \
         --log-level=debug \
         --network-bin-dir=/home/cri-containerd/opt/cni/bin \
-        --network-conf-dir=/home/cri-containerd/etc/cni/net.d
+        --network-conf-dir=/home/cri-containerd/etc/cni/net.d \
+        --cgroup-path=/runtime
 
       [Install]
       WantedBy=cri-containerd.target


### PR DESCRIPTION
This PR:
1) Add `/runtime` cgroup for containerd and cri-containerd in e2e test. So that our resource usage test in https://k8s-testgrid.appspot.com/sig-node-containerd#node-e2e-serial can get full runtime resource usage. @yanxuean @miaoyq 
2) Fix `cri-containerd default-config` panic. I don't understand why it panics, but this PR does fix it by removing a level of embedded struct `CRIConfig`. See https://github.com/BurntSushi/toml/issues/211.

Signed-off-by: Lantao Liu <lantaol@google.com>