### PR TITLE
Put version into metadata so that version won't be changed across reboot.

### DIFF
--- a/cluster/gce/configure.sh
+++ b/cluster/gce/configure.sh
@@ -43,13 +43,12 @@ DEPLOY_PATH=${DEPLOY_PATH:-"cri-containerd-release"}
 # By default use the release tarball with cni built in.
 PKG_PREFIX=${PKG_PREFIX:-"cri-containerd-cni"}
 
-# VERSION is the cri-containerd version to use. If not specified,
-# the latest version will be used.
+# VERSION is the cri-containerd version to use.
 VERSION_METADATA="version"
 VERSION=$(fetch_metadata "${VERSION_METADATA}")
 if [ -z "${VERSION}" ]; then
-  VERSION=$(curl -f --ipv4 --retry 6 --retry-delay 3 --silent --show-error \
-    https://storage.googleapis.com/${DEPLOY_PATH}/latest)
+  echo "Version is not set."
+  exit 1
 fi
 
 # TARBALL_GCS_PATH is the path to download cri-containerd tarball for node e2e.

--- a/cluster/gce/env
+++ b/cluster/gce/env
@@ -3,14 +3,14 @@ GCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # TODO(random-liu): Upload release tarball to user's own GCS, and use it. We should
 # not let all nodes of all users download tarball from cri-containerd-release.
-export KUBE_MASTER_EXTRA_METADATA="user-data=${GCE_DIR}/cloud-init/master.yaml,cri-containerd-configure-sh=${GCE_DIR}/configure.sh"
-export KUBE_NODE_EXTRA_METADATA="user-data=${GCE_DIR}/cloud-init/node.yaml,cri-containerd-configure-sh=${GCE_DIR}/configure.sh"
-if [ -n "${CRI_CONTAINERD_VERSION}" ]; then
-  version=$(mktemp /tmp/version.XXXX)
-  echo "${CRI_CONTAINERD_VERSION}" > "$version"
-  export KUBE_MASTER_EXTRA_METADATA="${KUBE_MASTER_EXTRA_METADATA},version=${version}"
-  export KUBE_NODE_EXTRA_METADATA="${KUBE_NODE_EXTRA_METADATA},version=${version}"
+if [ -z "${CRI_CONTAINERD_VERSION:-}" ]; then
+  CRI_CONTAINERD_VERSION=$(curl -f --ipv4 --retry 6 --retry-delay 3 --silent --show-error \
+    https://storage.googleapis.com/cri-containerd-release/latest)
 fi
+version_file=$(mktemp /tmp/version.XXXX)
+echo "${CRI_CONTAINERD_VERSION}" > "$version_file"
+export KUBE_MASTER_EXTRA_METADATA="user-data=${GCE_DIR}/cloud-init/master.yaml,cri-containerd-configure-sh=${GCE_DIR}/configure.sh,version=${version_file}"
+export KUBE_NODE_EXTRA_METADATA="user-data=${GCE_DIR}/cloud-init/node.yaml,cri-containerd-configure-sh=${GCE_DIR}/configure.sh,version=${version_file}"
 export KUBE_CONTAINER_RUNTIME="remote"
 export KUBE_CONTAINER_RUNTIME_ENDPOINT="/var/run/cri-containerd.sock"
 export KUBE_LOAD_IMAGE_COMMAND="/home/cri-containerd/usr/local/bin/cri-containerd load"

--- a/test/configure.sh
+++ b/test/configure.sh
@@ -58,6 +58,8 @@ fi
 
 # VERSION is the latest cri-containerd version got from cri-containerd gcs
 # bucket.
+# TODO(random-liu): Put version into the metadata instead of
+# deciding it in cloud init. This may cause issue to reboot test.
 VERSION=$(curl -f --ipv4 --retry 6 --retry-delay 3 --silent --show-error \
   https://storage.googleapis.com/${DEPLOY_PATH}/latest)
 # TARBALL_GCS_PATH is the path to download cri-containerd tarball for node e2e.


### PR DESCRIPTION
Cloud-init script will run whenever node reboot. Previously we get version from `https://storage.googleapis.com/cri-containerd-release/latest` in the cloud init script.

However, if the latest version changed before reboot, the node will download a new version of cri-containerd during reboot, which might not be compatible with the Kubernetes version in use.

We should fix the version in instance metadata.

Signed-off-by: Lantao Liu <lantaol@google.com>