### PR TITLE
Add golang version in `Status` info.

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -19,6 +19,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	goruntime "runtime"
 
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
@@ -70,6 +71,11 @@ func (c *criContainerdService) Status(ctx context.Context, r *runtime.StatusRequ
 		}
 		resp.Info = make(map[string]string)
 		resp.Info["config"] = string(configByt)
+		versionByt, err := json.Marshal(goruntime.Version())
+		if err != nil {
+			return nil, err
+		}
+		resp.Info["golang"] = string(versionByt)
 	}
 	return resp, nil
 }


### PR DESCRIPTION
I feel like it's useful to show golang version in `crictl info`.
I feel like for `crictl info`, order is not so important, so don't put everything into one big struct for now.

```console
{
  "status": {
    "conditions": [
      {
        "type": "RuntimeReady",
        "status": true,
        "reason": "",
        "message": ""
      },
      {
        "type": "NetworkReady",
        "status": true,
        "reason": "",
        "message": ""
      }
    ]
  },
  "config": {
    "containerd": {
      "snapshotter": "overlayfs",
      "runtime": "io.containerd.runtime.v1.linux"
    },
    "cni": {
      "binDir": "/opt/cni/bin",
      "confDir": "/etc/cni/net.d"
    },
    "registry": {},
    "streamServerPort": "10010",
    "sandboxImage": "gcr.io/google_containers/pause:3.0",
    "statsCollectPeriod": 10,
    "containerdRootDir": "/var/lib/containerd",
    "containerdEndpoint": "/run/containerd/containerd.sock",
    "socketPath": "/var/run/cri-containerd.sock",
    "rootDir": "/var/lib/cri-containerd",
    "oomScore": -999,
    "enableProfiling": true,
    "profilingPort": "10011",
    "profilingAddress": "127.0.0.1",
    "logLevel": "info"
  },
  "golang": "go1.9.2"
}
```
Signed-off-by: Lantao Liu <lantaol@google.com>