### PR TITLE
Add a separate CLI for cri-containerd `ctrcri`.

### DIFF
--- a/cluster/gce/env
+++ b/cluster/gce/env
@@ -13,7 +13,7 @@ if [ -n "${CRI_CONTAINERD_VERSION}" ]; then
 fi
 export KUBE_CONTAINER_RUNTIME="remote"
 export KUBE_CONTAINER_RUNTIME_ENDPOINT="/var/run/cri-containerd.sock"
-export KUBE_LOAD_IMAGE_COMMAND="/home/cri-containerd/usr/local/bin/cri-containerd load"
+export KUBE_LOAD_IMAGE_COMMAND="/home/cri-containerd/usr/local/bin/ctrcri load"
 export NETWORK_POLICY_PROVIDER="calico"
 export NON_MASQUERADE_CIDR="0.0.0.0/0"
 export KUBE_KUBELET_ARGS="--runtime-cgroups=/runtime"

--- a/cmd/cri-containerd/cri_containerd.go
+++ b/cmd/cri-containerd/cri_containerd.go
@@ -82,7 +82,6 @@ func main() {
 	o.AddFlags(cmd.Flags())
 	cmd.AddCommand(defaultConfigCommand())
 	cmd.AddCommand(versionCommand())
-	cmd.AddCommand(loadImageCommand())
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		setupDumpStacksTrap()

--- a/cmd/cri-containerd/options/options.go
+++ b/cmd/cri-containerd/options/options.go
@@ -19,7 +19,6 @@ package options
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/containerd/containerd"
@@ -31,8 +30,6 @@ const (
 	configFilePathArgName = "config"
 	// defaultConfigFilePath is the default config file path.
 	defaultConfigFilePath = "/etc/cri-containerd/config.toml"
-	// connectionTimeout is the grpc connection timeout.
-	connectionTimeout = 10 * time.Second
 )
 
 // ContainerdConfig contains toml config related to containerd
@@ -232,13 +229,6 @@ func PrintDefaultTomlConfig() {
 		fmt.Println(err)
 		return
 	}
-}
-
-// AddGRPCFlags add flags for grpc connection.
-func AddGRPCFlags(fs *pflag.FlagSet) (*string, *time.Duration) {
-	endpoint := fs.String("endpoint", DefaultConfig().SocketPath, "cri-containerd endpoint.")
-	timeout := fs.Duration("timeout", connectionTimeout, "cri-containerd connection timeout.")
-	return endpoint, timeout
 }
 
 // DefaultConfig returns default configurations of cri-containerd.

--- a/cmd/ctrcri/ctrcri.go
+++ b/cmd/ctrcri/ctrcri.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2018 The Containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/containerd/cri-containerd/cmd/cri-containerd/options"
+	"github.com/containerd/cri-containerd/pkg/version"
+)
+
+const (
+	// Add \u200B to avoid the space trimming.
+	desc = "\u200B" + `        __                 _ 
+  _____/ /________________(_)
+ / ___/ __/ ___/ ___/ ___/ / 
+/ /__/ /_/ /  / /__/ /  / /  
+\___/\__/_/   \___/_/  /_/   
+
+containerd CRI plugin CLI
+`
+	command = "ctrcri"
+)
+
+var cmd = &cobra.Command{
+	Use:   command,
+	Short: "A CLI for containerd CRI plugin.",
+	Long:  desc,
+}
+
+var (
+	// address is the address for containerd's GRPC server.
+	address string
+	// timeout is the timeout for containerd grpc connection.
+	timeout time.Duration
+	// defaultTimeout is the default timeout for containerd grpc connection.
+	defaultTimeout = 10 * time.Second
+)
+
+func addGlobalFlags(fs *pflag.FlagSet) {
+	// TODO(random-liu): Change default to containerd/defaults.DefaultAddress after cri plugin
+	// become default.
+	fs.StringVar(&address, "address", options.DefaultConfig().SocketPath, "address for containerd's GRPC server.")
+	fs.DurationVar(&timeout, "timeout", defaultTimeout, "timeout for containerd grpc connection.")
+}
+
+func versionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print " + command + " version information.",
+		Run: func(cmd *cobra.Command, args []string) {
+			version.PrintVersion()
+		},
+	}
+}
+
+func main() {
+	addGlobalFlags(cmd.PersistentFlags())
+
+	cmd.AddCommand(versionCommand())
+	cmd.AddCommand(loadImageCommand())
+	if err := cmd.Execute(); err != nil {
+		// Error should have been reported.
+		os.Exit(1)
+	}
+}

--- a/cmd/ctrcri/load.go
+++ b/cmd/ctrcri/load.go
@@ -25,7 +25,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 
-	"github.com/containerd/cri-containerd/cmd/cri-containerd/options"
 	api "github.com/containerd/cri-containerd/pkg/api/v1"
 	"github.com/containerd/cri-containerd/pkg/client"
 )
@@ -41,21 +40,20 @@ var (
 		TAR - The path to a tar archive containing a container image.
 
 		Requirement:
-			Containerd and cri-containerd daemons (grpc servers) must already be up and
-			running before the load command is used.
+			Containerd and its cri plugin must already be up and running before the load
+			command is used.
 
 		Description:
-			Running as a client, cri-containerd implements the load command by sending the
-			load request to the already running cri-containerd daemon/server, which in
-			turn loads the image into containerd's image storage via the already running
-			containerd daemon.`)
+			Running as a client, ` + command + ` implements the load command by sending the
+			load request to the already running containerd daemon/server, which in
+			turn loads the image into containerd's image storage.`)
 
 	loadExample = dedent(`
 		- use docker to pull the latest busybox image and save it as a tar archive:
 			$ docker pull busybox:latest
 			$ docker save busybox:latest -o busybox.tar
-		- use cri-containerd to load the image into containerd's image storage:
-			$ cri-containerd load busybox.tar`)
+		- use ` + command + ` to load the image into containerd's image storage:
+			$ ` + command + ` load busybox.tar`)
 )
 
 func loadImageCommand() *cobra.Command {
@@ -67,9 +65,8 @@ func loadImageCommand() *cobra.Command {
 		Example: loadExample,
 	}
 	c.SetUsageTemplate(strings.Replace(c.UsageTemplate(), "Examples:", "Example:", 1))
-	endpoint, timeout := options.AddGRPCFlags(c.Flags())
 	c.RunE = func(cmd *cobra.Command, args []string) error {
-		cl, err := client.NewCRIContainerdClient(*endpoint, *timeout)
+		cl, err := client.NewCRIContainerdClient(address, timeout)
 		if err != nil {
 			return fmt.Errorf("failed to create grpc client: %v", err)
 		}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,6 +7,7 @@ These steps have been verified on Ubuntu 16.04. For other OS distributions, the 
 ## Release Tarball
 For each release, we'll publish a release tarball. The release tarball contains all required binaries and files for `cri-containerd`.
 ### Content
+<!-- TODO(random-liu): Update the release tarball information -->
 As shown below, the release tarball contains:
 1) `cri-containerd`: cri-containerd binary.
 2) `containerd`, `containerd-shim`, `containerd-stress`, `containerd-release`, `ctr`: binaries for containerd.


### PR DESCRIPTION
Add a separate CLI for cri-containerd called `ctrcri`, basically a `ctr` for CRI plugin. I know the name is bad and confusing, but I could not come up with a better name...

We need a separate CLI. Today we use `cri-containerd load`. However, after switching to plugin mode, we don't have a `cri-containerd` binary. We have to support `load` somewhere, so we added `ctrcri`.

This works with both standalone `cri-containerd` and containerd cri plugin.

The CLI is used for image load for now, which is required for cluster bootstrapping today. We may add new subcommand in the future if we have to.

`ctrcri` isn't targeted to be a user facing tool. User should only use `kubectl` or `crictl` in most cases.

```console
$ ctrcri
        __                 _ 
  _____/ /________________(_)
 / ___/ __/ ___/ ___/ ___/ / 
/ /__/ /_/ /  / /__/ /  / /  
\___/\__/_/   \___/_/  /_/   

containerd CRI plugin CLI

Usage:
  ctrcri [command]

Available Commands:
  help        Help about any command
  load        Load an image from a tar archive.
  version     Print ctrcri version information.

Flags:
      --address string     address for containerd's GRPC server. (default "/var/run/cri-containerd.sock")
  -h, --help               help for ctrcri
      --timeout duration   timeout for containerd grpc connection. (default 10s)

Use "ctrcri [command] --help" for more information about a command.
```
Signed-off-by: Lantao Liu <lantaol@google.com>