### PR TITLE
Use registry-1.docker.io as backup

### DIFF
--- a/cluster/gce/cloud-init/master.yaml
+++ b/cluster/gce/cloud-init/master.yaml
@@ -89,7 +89,7 @@ write_files:
         --network-bin-dir=/home/cri-containerd/opt/cni/bin \
         --network-conf-dir=/home/cri-containerd/etc/cni/net.d \
         --cgroup-path=/runtime \
-        --registry=docker.io=https://mirror.gcr.io
+        --registry=docker.io=https://mirror.gcr.io,https://registry-1.docker.io
 
       [Install]
       WantedBy=cri-containerd.target

--- a/cluster/gce/cloud-init/node.yaml
+++ b/cluster/gce/cloud-init/node.yaml
@@ -92,7 +92,7 @@ write_files:
         --network-bin-dir=/home/kubernetes/bin \
         --network-conf-dir=/etc/cni/net.d \
         --cgroup-path=/runtime \
-        --registry=docker.io=https://mirror.gcr.io
+        --registry=docker.io=https://mirror.gcr.io,https://registry-1.docker.io
 
       [Install]
       WantedBy=cri-containerd.target

--- a/test/e2e_node/init.yaml
+++ b/test/e2e_node/init.yaml
@@ -86,7 +86,7 @@ write_files:
         --network-bin-dir=/home/cri-containerd/opt/cni/bin \
         --network-conf-dir=/home/cri-containerd/etc/cni/net.d \
         --cgroup-path=/runtime \
-        --registry=docker.io=https://mirror.gcr.io
+        --registry=docker.io=https://mirror.gcr.io,https://registry-1.docker.io
 
       [Install]
       WantedBy=cri-containerd.target


### PR DESCRIPTION
@abhi has a good point. We should not use docker.io as fallback in the code. We should use configuration to specify that.

Signed-off-by: Lantao Liu <lantaol@google.com>