### PR TITLE
Create cni configuration directory if it does not present.

### DIFF
--- a/cluster/gce/cloud-init/node.yaml
+++ b/cluster/gce/cloud-init/node.yaml
@@ -14,9 +14,6 @@ write_files:
       [Service]
       Type=oneshot
       RemainAfterExit=yes
-      # cri-containerd requires the existence of cni config directory.
-      # TODO(random-liu): Eliminate the requirement in ocicni.
-      ExecStartPre=/bin/mkdir -p /etc/cni/net.d
       ExecStartPre=/bin/mkdir -p /home/cri-containerd
       ExecStartPre=/bin/mount --bind /home/cri-containerd /home/cri-containerd
       ExecStartPre=/bin/mount -o remount,exec /home/cri-containerd

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -87,6 +87,7 @@ curl https://storage.googleapis.com/cri-containerd-release/cri-containerd-${VERS
 ```
 ## Step 2: Install CRI-Containerd
 If you are using systemd, just simply unpack the tarball to the root directory:
+<!-- TODO(random-liu): Remove cni directory operations after we deprecate v1.0.0-beta.1 -->
 ```bash
 sudo tar -C / -xzf cri-containerd-${VERSION}.linux-amd64.tar.gz
 sudo mkdir -p /opt/cni/bin/

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -149,6 +149,10 @@ func NewCRIContainerdService(config options.Config) (CRIContainerdService, error
 		logrus.Warn("Skip retrieving imagefs UUID, kubelet will not be able to get imagefs capacity or perform imagefs disk eviction.")
 	}
 
+	// ocicni requires the cni config directory to exist, so make sure it is there.
+	if err := os.MkdirAll(config.NetworkPluginConfDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create cni config directory %q: %v", err, config.NetworkPluginConfDir)
+	}
 	c.netPlugin, err = ocicni.InitCNI(config.NetworkPluginConfDir, config.NetworkPluginBinDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize cni plugin: %v", err)


### PR DESCRIPTION
Part of https://github.com/containerd/cri-containerd/issues/573.

Today, `cri-containerd` and `ocicni` fails if cni conf directory does not exist.

However, after `cri-containerd` becomes a plugin of containerd, it doesn't make sense to let user always create `/etc/cni/net.d` before start containerd.

So let `cri-containerd` ensure that itself.

Signed-off-by: Lantao Liu <lantaol@google.com>