### PR TITLE
Remove critest from release tarball.

### DIFF
--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -106,7 +106,7 @@ ${sudo} make install -e DESTDIR=${RUNC_DIR}
 if ${INSTALL_CNI}; then
   checkout_repo ${CNI_PKG} ${CNI_VERSION}
   cd ${GOPATH}/src/${CNI_PKG}
-  ./build.sh
+  FASTBUILD=true ./build.sh
   ${sudo} mkdir -p ${CNI_DIR}
   ${sudo} cp -r ./bin ${CNI_DIR}
   ${sudo} mkdir -p ${CNI_CONFIG_DIR}
@@ -177,9 +177,8 @@ ${sudo} sh -c "PATH=${PATH} make install -e DESTDIR=${CONTAINERD_DIR}"
 #Install crictl
 checkout_repo ${CRITOOL_PKG} ${CRITOOL_VERSION}
 cd ${GOPATH}/src/${CRITOOL_PKG}
-make
-# make install critools require GOPATH to be set correctly.
-${sudo} make install -e BINDIR=${CRICTL_DIR} GOPATH=${GOPATH}
+make crictl
+${sudo} install -D -m 755 ${GOPATH}/bin/crictl ${CRICTL_DIR}/crictl
 ${sudo} mkdir -p ${CRICTL_CONFIG_DIR}
 ${sudo} bash -c 'cat >'${CRICTL_CONFIG_DIR}'/crictl.yaml <<EOF
 runtime-endpoint: /var/run/cri-containerd.sock


### PR DESCRIPTION
This PR:
1) Remove `critest` from release tarball. `critest` requires `cri-tools` repo to work. The binary itself is not usable.
2) Add `FASTBUILD=true` for cni plugins build, which accelerate build process a lot.

Signed-off-by: Lantao Liu <lantaol@google.com>