### PR TITLE
Remove wrong comment. CRI is actually a grpc plugin of containerd now.

### DIFF
--- a/cri.go
+++ b/cri.go
@@ -32,7 +32,6 @@ import (
 func init() {
 	config := options.DefaultConfig().PluginConfig
 	plugin.Register(&plugin.Registration{
-		// In fact, cri is not strictly a GRPC plugin now.
 		Type:   plugin.GRPCPlugin,
 		ID:     "cri",
 		Config: &config,


### PR DESCRIPTION
Remove wrong comment. CRI is a service registered on containerd grpc server now.

Signed-off-by: Lantao Liu <lantaol@google.com>