### PR TITLE
Do not fast build.

### DIFF
--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -105,7 +105,7 @@ ${sudo} make install -e DESTDIR=${RUNC_DIR}
 if ${INSTALL_CNI}; then
   checkout_repo ${CNI_PKG} ${CNI_VERSION} ${CNI_REPO}
   cd ${GOPATH}/src/${CNI_PKG}
-  FASTBUILD=true ./build.sh
+  ./build.sh
   ${sudo} mkdir -p ${CNI_DIR}
   ${sudo} cp -r ./bin ${CNI_DIR}
   ${sudo} mkdir -p ${CNI_CONFIG_DIR}


### PR DESCRIPTION
Although not sure why. After https://github.com/containerd/cri-containerd/commit/78f3df285f209b4e5ae54787ed9ae159bb0e785a got merged, device-plugin-gpu test become very flaky. https://k8s-testgrid.appspot.com/sig-node-containerd#e2e-gci-device-plugin-gpu

I can't find any other suspicious change around that time, so revert this to see whether it fixes it.

/cc @mikebrow 

Signed-off-by: Lantao Liu <lantaol@google.com>