### PR TITLE
adds lower case containerd to the list of authors

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -218,7 +218,7 @@ def get_regexs():
     # strip #!.* from shell scripts
     regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
     regexs["authors"] = re.compile( 'AUTHORS' )
-    authors = [ 'The Kubernetes Authors', 'The Containerd Authors' ]
+    authors = [ 'The Kubernetes Authors', 'The Containerd Authors', 'The containerd Authors' ]
     regexs["auth"] = re.compile( '(%s)' % "|".join(map(lambda l: str(l), authors)) )
     regexs["copyright"] = re.compile( 'Copyright YEAR AUTHORS' )
     return regexs


### PR DESCRIPTION
The group wants to use "The containerd Authors" see https://github.com/containerd/containerd/pull/2108

IMO both containerd and Containerd seek to cover the same group from a copyright perspective.. so for the purpose of boilerplate verification I at least want to make sure we support the all lower case option. If desired I can sed through the files, remove "Containerd" and force "The containerd Authors" but for now I'd rather just support both in boilerplate verify.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>