### PR TITLE
Support reopening container log.

### DIFF
--- a/hack/versions
+++ b/hack/versions
@@ -10,5 +10,5 @@ if [ x"$KUBERNETES_REPO" = "xk8s.io" ] ; then
 fi
 
 # Not from vendor.conf.
-CRITOOL_VERSION=240a840375cdabb5860c75c99e8b0d0a776006b4
+CRITOOL_VERSION=c87ea764cecbcbabbb51c5bdd10ea317181fdd62
 CRITOOL_REPO=github.com/kubernetes-incubator/cri-tools

--- a/pkg/server/container_attach.go
+++ b/pkg/server/container_attach.go
@@ -77,8 +77,6 @@ func (c *criContainerdService) attachContainer(ctx context.Context, id string, s
 		},
 	}
 	// TODO(random-liu): Figure out whether we need to support historical output.
-	if err := cntr.IO.Attach(opts); err != nil {
-		return fmt.Errorf("failed to attach container: %v", err)
-	}
+	cntr.IO.Attach(opts)
 	return nil
 }

--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -110,9 +110,7 @@ func (c *criContainerdService) startContainer(ctx context.Context,
 				}
 			}
 		}()
-		if err := cio.WithOutput("log", stdoutWC, stderrWC)(cntr.IO); err != nil {
-			return nil, fmt.Errorf("failed to add container log: %v", err)
-		}
+		cntr.IO.AddOutput("log", stdoutWC, stderrWC)
 		cntr.IO.Pipe()
 		return cntr.IO, nil
 	}

--- a/pkg/server/restart.go
+++ b/pkg/server/restart.go
@@ -161,11 +161,11 @@ func loadContainer(ctx context.Context, cntr containerd.Container, containerDir 
 		}
 		containerIO, err = cio.NewContainerIO(id,
 			cio.WithFIFOs(fifos),
-			cio.WithOutput("log", stdoutWC, stderrWC),
 		)
 		if err != nil {
 			return nil, err
 		}
+		containerIO.AddOutput("log", stdoutWC, stderrWC)
 		containerIO.Pipe()
 		return containerIO, nil
 	})


### PR DESCRIPTION
Support reopening container log.
The PR for kubelet is coming soon.
The PR for critest is https://github.com/kubernetes-incubator/cri-tools/pull/242. And the critest has passed:
```console
[k8s.io] Container runtime should support log 
  runtime should support reopening container log [Conformance]
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/container.go:226
[BeforeEach] [k8s.io] Container
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/framework.go:50
[BeforeEach] [k8s.io] Container
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/container.go:63
[BeforeEach] runtime should support log
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/container.go:194
STEP: create a PodSandbox with log directory
[It] runtime should support reopening container log [Conformance]
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/container.go:226
STEP: create container with log
STEP: create a container with log and name
STEP: Get image status for image: busybox:1.26
STEP: Create container.
Feb 13 01:44:53.692: INFO: Created container "4e12a1578c465c15a409a24cf279ccab38f191e57603a3c80699b15f26a8c7cb"

STEP: start container with log
STEP: Start container for containerID: 4e12a1578c465c15a409a24cf279ccab38f191e57603a3c80699b15f26a8c7cb
Feb 13 01:44:53.828: INFO: Started container "4e12a1578c465c15a409a24cf279ccab38f191e57603a3c80699b15f26a8c7cb"

Feb 13 01:44:53.828: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log
Feb 13 01:44:53.828: INFO: Parse container log succeed
STEP: rename container log
STEP: reopen container log
Feb 13 01:44:53.829: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log
Feb 13 01:44:53.829: INFO: Parse container log succeed
Feb 13 01:44:54.830: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log
Feb 13 01:44:54.830: INFO: Parse container log succeed
Feb 13 01:44:54.830: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log.new
Feb 13 01:44:54.830: INFO: Parse container log succeed
Feb 13 01:44:54.830: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log.new
Feb 13 01:44:54.830: INFO: Parse container log succeed
Feb 13 01:44:55.830: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log.new
Feb 13 01:44:55.830: INFO: Parse container log succeed
Feb 13 01:44:56.831: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log.new
Feb 13 01:44:56.831: INFO: Parse container log succeed
Feb 13 01:44:57.831: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log.new
Feb 13 01:44:57.831: INFO: Parse container log succeed
Feb 13 01:44:58.832: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log.new
Feb 13 01:44:58.832: INFO: Parse container log succeed
[AfterEach] runtime should support log
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/container.go:198
STEP: stop PodSandbox
STEP: delete PodSandbox
STEP: clean up the TempDir
[AfterEach] [k8s.io] Container
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/framework.go:51

• [SLOW TEST:7.404 seconds]
[k8s.io] Container
/home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/framework.go:72
  runtime should support log
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/container.go:190
    runtime should support reopening container log [Conformance]
    /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/container.go:226
```
Signed-off-by: Lantao Liu <lantaol@google.com>