### PR TITLE
Do not block on stream server close.

### DIFF
--- a/cluster/gce/cloud-init/master.yaml
+++ b/cluster/gce/cloud-init/master.yaml
@@ -106,7 +106,6 @@ write_files:
       Restart=always
       RestartSec=10
       RemainAfterExit=yes
-      RemainAfterExit=yes
       ExecStartPre=/bin/chmod 544 /home/cri-containerd/opt/cri-containerd/cluster/health-monitor.sh
       ExecStart=/bin/bash -c 'CRICTL=/home/cri-containerd/usr/local/bin/crictl \
       /home/cri-containerd/opt/cri-containerd/cluster/health-monitor.sh'
@@ -175,7 +174,6 @@ write_files:
       [Service]
       Restart=always
       RestartSec=10
-      RemainAfterExit=yes
       RemainAfterExit=yes
       ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/health-monitor.sh
       ExecStart=/home/kubernetes/bin/health-monitor.sh kubelet

--- a/cluster/gce/cloud-init/node.yaml
+++ b/cluster/gce/cloud-init/node.yaml
@@ -106,7 +106,6 @@ write_files:
       Restart=always
       RestartSec=10
       RemainAfterExit=yes
-      RemainAfterExit=yes
       ExecStartPre=/bin/chmod 544 /home/cri-containerd/opt/cri-containerd/cluster/health-monitor.sh
       ExecStart=/bin/bash -c 'CRICTL=/home/cri-containerd/usr/local/bin/crictl \
       /home/cri-containerd/opt/cri-containerd/cluster/health-monitor.sh'
@@ -174,7 +173,6 @@ write_files:
       [Service]
       Restart=always
       RestartSec=10
-      RemainAfterExit=yes
       RemainAfterExit=yes
       ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/health-monitor.sh
       ExecStart=/home/kubernetes/bin/health-monitor.sh kubelet


### PR DESCRIPTION
In e2e test, I sometimes see that when cri-containerd is starting, it is killed by health-monitor, and then stuck forever:
```
Started Kubernetes containerd CRI shim.
time="2018-02-13T02:26:55Z" level=info msg="Run cri-containerd "
time="2018-02-13T02:26:55Z" level=info msg="Start profiling server"
time="2018-02-13T02:26:55Z" level=info msg="Run cri-containerd grpc server on socket "/var/run/cri-containerd.sock""
time="2018-02-13T02:26:55Z" level=info msg="Get image filesystem path "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs""
I0213 02:26:55.155330    2490 interface.go:360] Looking for default routes with IPv4 addresses
I0213 02:26:55.155351    2490 interface.go:365] Default route transits interface "eth0"
I0213 02:26:55.155458    2490 interface.go:174] Interface eth0 is up
I0213 02:26:55.155516    2490 interface.go:222] Interface "eth0" has 2 addresses :[10.128.0.5/32 fe80::4001:aff:fe80:5/64].
I0213 02:26:55.155538    2490 interface.go:189] Checking addr  10.128.0.5/32.
I0213 02:26:55.155548    2490 interface.go:196] IP found 10.128.0.5
I0213 02:26:55.155559    2490 interface.go:228] Found valid IPv4 address 10.128.0.5 for interface "eth0".
I0213 02:26:55.155569    2490 interface.go:371] Found active IP 10.128.0.5
time="2018-02-13T02:26:55Z" level=error msg="error updating cni config: Missing CNI default network"
time="2018-02-13T02:26:55Z" level=info msg="Initial CNI setting failed, continue monitoring: Missing CNI default network"
time="2018-02-13T02:26:55Z" level=info msg="Start cri-containerd service"
time="2018-02-13T02:26:55Z" level=info msg="Connect containerd service"
time="2018-02-13T02:26:55Z" level=info msg="Stop cri-containerd service"
time="2018-02-13T02:26:55Z" level=info msg="Start subscribing containerd event"
time="2018-02-13T02:26:55Z" level=info msg="Start recovering state"
time="2018-02-13T02:26:55Z" level=info msg="Start event monitor"
time="2018-02-13T02:26:55Z" level=info msg="Start snapshots syncer"
time="2018-02-13T02:26:55Z" level=info msg="Start streaming server"
time="2018-02-13T02:26:55Z" level=info msg="Start grpc server"
time="2018-02-13T02:26:55Z" level=error msg="Failed to serve grpc request" error="grpc: the server has been stopped"
time="2018-02-13T02:26:55Z" level=info msg="Stop cri-containerd service"
time="2018-02-13T02:26:55Z" level=error msg="Failed to handle event stream" error="rpc error: code = Canceled desc = context canceled"
time="2018-02-13T02:26:55Z" level=info msg="Event monitor stopped"
```

The reason is that there is a race condition between `http.Server.Serve()` and `http.Server.Close()`, which are used by stream server. (The issue https://github.com/golang/go/issues/20239). There is no reliable, race free way to wait for stream server to stop. So we add a timeout here. In most cases, we'll still wait for stream server to stop. However, if we hit the race condition, we'll wait for 2 seconds, throw out an error and continue stopping.

Signed-off-by: Lantao Liu <lantaol@google.com>