### PR TITLE
Add initial wait for health-monitor and use pkill -x.

### DIFF
--- a/hack/test-utils.sh
+++ b/hack/test-utils.sh
@@ -45,7 +45,8 @@ test_setup() {
     echo "containerd is not installed, please run hack/install-deps.sh"
     exit 1
   fi
-  sudo pkill containerd
+  sudo pkill -x cri-containerd
+  sudo pkill -x containerd
   keepalive "sudo containerd" ${RESTART_WAIT_PERIOD} &> ${report_dir}/containerd.log &
   containerd_pid=$!
   # Wait for containerd to be running by using the containerd client ctr to check the version
@@ -69,7 +70,8 @@ test_teardown() {
   if [ -n "${cri_containerd_pid}" ]; then
     kill ${cri_containerd_pid}
   fi
-  sudo pkill containerd
+  sudo pkill -x cri-containerd
+  sudo pkill -x containerd
 }
 
 # keepalive runs a command and keeps it alive.

--- a/integration/test_utils.go
+++ b/integration/test_utils.go
@@ -206,7 +206,7 @@ func Randomize(str string) string {
 
 // KillProcess kills the process by name. pkill is used.
 func KillProcess(name string) error {
-	output, err := exec.Command("pkill", fmt.Sprintf("^%s$", name)).CombinedOutput()
+	output, err := exec.Command("pkill", "-x", fmt.Sprintf("^%s$", name)).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to kill %q - error: %v, output: %q", name, err, output)
 	}


### PR DESCRIPTION
Add `INITIAL_WAIT_SECONDS` for health-monitor. And use `pkill -x` to do exact match. https://gsp.com/cgi-bin/man.cgi?section=1&topic=pkill

Signed-off-by: Lantao Liu <lantaol@google.com>