### PR TITLE
Update critools and run critest in parallel.

### DIFF
--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -104,7 +104,7 @@ ${sudo} make install -e DESTDIR=${RUNC_DIR}
 if ${INSTALL_CNI}; then
   checkout_repo ${CNI_PKG} ${CNI_VERSION} ${CNI_REPO}
   cd ${GOPATH}/src/${CNI_PKG}
-  ./build.sh
+  FASTBUILD=true ./build.sh
   ${sudo} mkdir -p ${CNI_DIR}
   ${sudo} cp -r ./bin ${CNI_DIR}
   ${sudo} mkdir -p ${CNI_CONFIG_DIR}

--- a/hack/test-cri.sh
+++ b/hack/test-cri.sh
@@ -52,7 +52,7 @@ mkdir -p ${REPORT_DIR}
 test_setup ${REPORT_DIR}
 
 # Run cri validation test
-sudo env PATH=${PATH} GOPATH=${GOPATH} ${CRITEST} --runtime-endpoint=${CRICONTAINERD_SOCK} --focus="${FOCUS}" --ginkgo-flags="--skip=\"${SKIP}\"" validation
+sudo env PATH=${PATH} GOPATH=${GOPATH} ${CRITEST} --runtime-endpoint=${CRICONTAINERD_SOCK} --focus="${FOCUS}" --ginkgo-flags="--skip=\"${SKIP}\" --nodes=8" validation
 test_exit_code=$?
 
 test_teardown

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -17,7 +17,7 @@
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 
 # Not from vendor.conf.
-CRITOOL_VERSION=c87ea764cecbcbabbb51c5bdd10ea317181fdd62
+CRITOOL_VERSION=8ec2cbda446377cab11a5ef8ef92e115aa628a91
 CRITOOL_REPO=github.com/kubernetes-incubator/cri-tools
 
 # upload_logs_to_gcs uploads test logs to gcs.


### PR DESCRIPTION
Update cri-tools to 8ec2cbda446377cab11a5ef8ef92e115aa628a91 and run `critest` in parallel.

Signed-off-by: Lantao Liu <lantaol@google.com>