### PR TITLE
Fix a potential panic

### DIFF
--- a/pkg/store/container/container.go
+++ b/pkg/store/container/container.go
@@ -39,7 +39,7 @@ type Container struct {
 	// Container IO
 	IO *cio.ContainerIO
 	// StopCh is used to propagate the stop information of the container.
-	store.StopCh
+	*store.StopCh
 }
 
 // Opts sets specific information to newly created Container.
@@ -80,7 +80,7 @@ func WithStatus(status Status, root string) Opts {
 func NewContainer(metadata Metadata, opts ...Opts) (Container, error) {
 	c := Container{
 		Metadata: metadata,
-		StopCh:   store.StopCh(make(chan struct{})),
+		StopCh:   store.NewStopCh(),
 	}
 	for _, o := range opts {
 		if err := o(&c); err != nil {

--- a/pkg/store/sandbox/sandbox.go
+++ b/pkg/store/sandbox/sandbox.go
@@ -37,7 +37,7 @@ type Sandbox struct {
 	// CNI network namespace client
 	NetNS *NetNS
 	// StopCh is used to propagate the stop information of the sandbox.
-	store.StopCh
+	*store.StopCh
 }
 
 // NewSandbox creates an internally used sandbox type. This functions reminds
@@ -46,7 +46,7 @@ func NewSandbox(metadata Metadata, status Status) Sandbox {
 	s := Sandbox{
 		Metadata: metadata,
 		Status:   StoreStatus(status),
-		StopCh:   store.StopCh(make(chan struct{})),
+		StopCh:   store.NewStopCh(),
 	}
 	if status.State == StateNotReady {
 		s.Stop()


### PR DESCRIPTION
When doing restart test for containerd/cri-containerd, I saw this panic:
```
time="2018-02-22T01:29:30Z" level=info msg="TaskExit event &TaskExit{ContainerID:5572b0aff62a960b5e2082f9cbcdceb2b40c6148c4c0277cbe47f29300eac02c,ID:5572b0aff62a960b5e2082f9cbcdceb2b40c6148c4c0277cbe47f29300eac02c,Pid:23240,ExitStatus:137,ExitedAt:2018-02-22 01:29:30.09547447 +0000 UTC,}"  
panic: close of closed channel

goroutine 675 [running]:
github.com/containerd/cri-containerd/pkg/store.store.StopCh.Stop(...)
        /home/lantaol/workspace/src/github.com/containerd/cri-containerd/pkg/store/util.go:24
github.com/containerd/cri-containerd/pkg/server.handleContainerExit(0xc420340480, 0xc4202a4480, 0x40, 0xc42041a000, 0xb9, 0xc4202a44c0, 0x40, 0xc4201920d0, 0xc4203a6050, 0x47, ...)
        /home/lantaol/workspace/src/github.com/containerd/cri-containerd/pkg/server/events.go:197 +0x357
github.com/containerd/cri-containerd/pkg/server.(*eventMonitor).handleEvent(0xc4203eca00, 0xc420180180)
        /home/lantaol/workspace/src/github.com/containerd/cri-containerd/pkg/server/events.go:116 +0x562
github.com/containerd/cri-containerd/pkg/server.(*eventMonitor).start.func1(0xc4203eca00, 0xc42050a4e0)
        /home/lantaol/workspace/src/github.com/containerd/cri-containerd/pkg/server/events.go:82 +0x148
created by github.com/containerd/cri-containerd/pkg/server.(*eventMonitor).start
        /home/lantaol/workspace/src/github.com/containerd/cri-containerd/pkg/server/events.go:77 +0xf8
```

The reason is that:
1) A container is just stopped during restart recovery;
2) We see the container is stopped in `loadContainer`;
3) But the event is also seen and handled by event monitor.

In that case, `stopCh` will be closed twice. We should make `Stop()` idempotent.

/cc @miaoyq 
Signed-off-by: Lantao Liu <lantaol@google.com>