### PR TITLE
adds go 1.10 to ci test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,13 @@ jobs:
         - make .gitvalidation
         - make binaries
         - make containerd
-      go: 1.9.x
+      go: "1.9.x"
     - script:
         - make install.tools
         - make .gitvalidation
         - make binaries
         - make containerd
-      go: tip
+      go: "1.10"
     - stage: Test
       script:
         - make install.deps
@@ -52,7 +52,19 @@ jobs:
         - cat /tmp/test-integration/containerd.log
         - cat /tmp/test-cri/cri-containerd.log
         - cat /tmp/test-cri/containerd.log
-      go: 1.9.x
+      go: "1.9.x"
+      script:
+        - make install.deps
+        - make test
+        - make test-integration
+        - make test-cri
+      after_script:
+        # Abuse travis to preserve the log.
+        - cat /tmp/test-integration/cri-containerd.log
+        - cat /tmp/test-integration/containerd.log
+        - cat /tmp/test-cri/cri-containerd.log
+        - cat /tmp/test-cri/containerd.log
+      go: "1.10"
     - script:
         - make install.deps
         - make containerd
@@ -63,4 +75,15 @@ jobs:
         # Abuse travis to preserve the log.
         - cat /tmp/test-integration/containerd.log
         - cat /tmp/test-cri/containerd.log
-      go: 1.9.x
+      go: "1.9.x"
+    - script:
+        - make install.deps
+        - make containerd
+        - sudo make install-containerd
+        - make test-integration STANDALONE_CRI_CONTAINERD=false
+        - make test-cri STANDALONE_CRI_CONTAINERD=false
+      after_script:
+        # Abuse travis to preserve the log.
+        - cat /tmp/test-integration/containerd.log
+        - cat /tmp/test-cri/containerd.log
+      go: "1.10"


### PR DESCRIPTION
Moves travis tests from 1.9 and tip to 1.9 and 1.10 to sync with containerd's travis testing.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>