### PR TITLE
moving to go1.10 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,6 @@ before_script:
 jobs:
   include:
     - stage: Build
-      script:
-        - make install.tools
-        - make .gitvalidation
-        - make binaries
-        - make containerd
-      go: "1.9.x"
     - script:
         - make install.tools
         - make .gitvalidation
@@ -41,18 +35,6 @@ jobs:
         - make containerd
       go: "1.10"
     - stage: Test
-      script:
-        - make install.deps
-        - make test
-        - make test-integration
-        - make test-cri
-      after_script:
-        # Abuse travis to preserve the log.
-        - cat /tmp/test-integration/cri-containerd.log
-        - cat /tmp/test-integration/containerd.log
-        - cat /tmp/test-cri/cri-containerd.log
-        - cat /tmp/test-cri/containerd.log
-      go: "1.9.x"
     - script:
         - make install.deps
         - make test
@@ -65,17 +47,6 @@ jobs:
         - cat /tmp/test-cri/cri-containerd.log
         - cat /tmp/test-cri/containerd.log
       go: "1.10"
-    - script:
-        - make install.deps
-        - make containerd
-        - sudo make install-containerd
-        - make test-integration STANDALONE_CRI_CONTAINERD=false
-        - make test-cri STANDALONE_CRI_CONTAINERD=false
-      after_script:
-        # Abuse travis to preserve the log.
-        - cat /tmp/test-integration/containerd.log
-        - cat /tmp/test-cri/containerd.log
-      go: "1.9.x"
     - script:
         - make install.deps
         - make containerd

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ backport version of `libseccomp-dev` is required. See [travis.yml](.travis.yml) 
 2. Install other dependencies:
 * **`nsenter`**: Required by CNI and portforward.
 * **`socat`**: Required by portforward.
-3. Install and setup a go 1.9.x development environment.
+3. Install and setup a go 1.10 development environment.
 4. Make a local clone of this repository.
 5. Install binary dependencies by running the following command from your cloned `cri-containerd/` project directory:
 ```bash


### PR DESCRIPTION
addressing issue #626

From here on in we can start using 1.10 only golang features and thus will only test on 1.10 and up.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>