### PR TITLE
Expose cri version for CRI plugin.

### DIFF
--- a/cri.go
+++ b/cri.go
@@ -20,12 +20,17 @@ import (
 	"path/filepath"
 
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 
 	"github.com/containerd/cri-containerd/cmd/cri-containerd/options"
 	"github.com/containerd/cri-containerd/pkg/server"
 )
+
+// criVersion is the CRI version supported by the CRI plugin.
+const criVersion = "v1alpha2"
 
 // TODO(random-liu): Use github.com/pkg/errors for our errors.
 // Register CRI service plugin
@@ -49,6 +54,8 @@ func init() {
 }
 
 func initCRIService(ic *plugin.InitContext) (interface{}, error) {
+	ic.Meta.Platforms = []imagespec.Platform{platforms.DefaultSpec()}
+	ic.Meta.Exports = map[string]string{"CRIVersion": criVersion}
 	ctx := ic.Context
 	pluginConfig := ic.Config.(*options.PluginConfig)
 	c := options.Config{


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/2174.

Export CRI version for CRI plugin, so that we can see the cri version in `ctr plugins -d`:
```console
# ctr plugins -d
...
                      
Type:          io.containerd.grpc.v1
ID:            cri
Requires:     
               io.containerd.runtime.v1
               io.containerd.snapshotter.v1
               io.containerd.monitor.v1
               io.containerd.differ.v1
               io.containerd.metadata.v1
               io.containerd.content.v1
               io.containerd.gc.v1
Platforms:     linux/amd64
Exports:      
               CRIVersion      v1alpha2
```
Signed-off-by: Lantao Liu <lantaol@google.com>