### PR TITLE
fix broken default config

### DIFF
--- a/cmd/cri-containerd/options/options.go
+++ b/cmd/cri-containerd/options/options.go
@@ -239,6 +239,8 @@ func DefaultConfig() Config {
 				Runtime:       "io.containerd.runtime.v1.linux",
 				RuntimeEngine: "",
 				RuntimeRoot:   "",
+				RootDir:       "/var/lib/containerd",
+				Endpoint:      "/run/containerd/containerd.sock",
 			},
 			StreamServerAddress: "",
 			StreamServerPort:    "10010",


### PR DESCRIPTION
Fixes issue: #633

I reproduced the issue on master when running cri-containerd with the default config.toml generated by the default-config command with the following error:

```
Error: failed to run cri-containerd with grpc server: failed to initialize containerd client with endpoint "": failed to dial "": dial unix: missing address
```

Signed-off-by: Mike Brown <brownwm@us.ibm.com>