### PR TITLE
adds allways to ensure there is a version even if no tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+git:
+  depth: 150
+
 language: go
 
 sudo: required

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ BUILD_DIR := _output
 # VERSION is derived from the current tag for HEAD plus amends. Version is used
 # to set/overide the CRIContainerdVersion variable in the verison package for
 # cri-containerd.
-VERSION := $(shell git describe --tags --dirty)
+VERSION := $(shell git describe --tags --dirty --always)
 # strip the first char of the tag if it's a `v`
 VERSION := $(VERSION:v%=%)
 TARBALL_PREFIX := cri-containerd


### PR DESCRIPTION
If no tag is "found" we should at least fall back to the commit vs setting the version to nil. 

Maybe the root issue is the depth of the git clone, it's set to 50. Setting the clone depth to 150 and leaving the version change in for people that want a shallow clone or don't fetch tags.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>