### PR TITLE
Require ansible 2.4+.

### DIFF
--- a/contrib/ansible/README.md
+++ b/contrib/ansible/README.md
@@ -10,7 +10,7 @@ This document provides the steps to bring up a Kubernetes cluster using ansible 
 ### Prerequisites:
 - **OS**: Ubuntu 16.04 (will be updated with additional distros after testing)
 - **Python**: 2.7+
-- **Ansible**: 2.3+
+- **Ansible**: 2.4+
 
 ## Step 0:
 -  Install Ansible on the host where you will provision the cluster. This host may be one of the nodes you plan to include in your cluster. Installation instructions for Ansible are found [here](http://docs.ansible.com/ansible/latest/intro_installation.html).


### PR DESCRIPTION
`include_tasks` is added in ansible 2.4. I tried with ansible 2.3.2, and it reports error on `include_tasks`.
http://docs.ansible.com/ansible/2.4/include_tasks_module.html
```
ERROR! no action detected in task. This often indicates a misspelled module name, or incorrect module path.

The error appears to have been in '/home/lantaol/workspace/src/github.com/containerd/cri-containerd/contrib/ansible/cri-containerd.yaml': line 6, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    - include_vars: vars/vars.yaml # Contains tasks variables for installer
    - include_tasks: tasks/bootstrap_ubuntu.yaml # Contains tasks bootstrap components for ubuntu systems
      ^ here


The error appears to have been in '/home/lantaol/workspace/src/github.com/containerd/cri-containerd/contrib/ansible/cri-containerd.yaml': line 6, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    - include_vars: vars/vars.yaml # Contains tasks variables for installer
    - include_tasks: tasks/bootstrap_ubuntu.yaml # Contains tasks bootstrap components for ubuntu systems
      ^ here
```

Signed-off-by: Lantao Liu <lantaol@google.com>