### PR TITLE
Fix a potential panic.

### DIFF
--- a/pkg/server/events.go
+++ b/pkg/server/events.go
@@ -137,6 +137,7 @@ func (em *eventMonitor) handleEvent(evt *events.Envelope) {
 				return
 			}
 			logrus.WithError(err).Errorf("Failed to get container %q", e.ContainerID)
+			return
 		}
 		err = cntr.Status.UpdateSync(func(status containerstore.Status) (containerstore.Status, error) {
 			status.Reason = oomExitReason


### PR DESCRIPTION
We should not continue when there is an error. It may cause a panic.
Found this when reviewing https://github.com/containerd/cri-containerd/pull/628.

Ref https://github.com/containerd/cri-containerd/issues/642.

Signed-off-by: Lantao Liu <lantaol@google.com>