### PR TITLE
[in-process-integration] Start switching to direct function call

### DIFF
--- a/integration/test_utils.go
+++ b/integration/test_utils.go
@@ -33,13 +33,14 @@ import (
 
 	api "github.com/containerd/cri-containerd/pkg/api/v1"
 	"github.com/containerd/cri-containerd/pkg/client"
+	"github.com/containerd/cri-containerd/pkg/constants"
 	"github.com/containerd/cri-containerd/pkg/util"
 )
 
 const (
 	timeout            = 1 * time.Minute
 	pauseImage         = "gcr.io/google_containers/pause:3.0" // This is the same with default sandbox image.
-	k8sNamespace       = "k8s.io"                             // This is the same with server.k8sContainerdNamespace.
+	k8sNamespace       = constants.K8sContainerdNamespace
 	containerdEndpoint = "/run/containerd/containerd.sock"
 )
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2018 The Containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+// TODO(random-liu): Merge annotations package into this package.
+
+// K8sContainerdNamespace is the namespace we use to connect containerd.
+const K8sContainerdNamespace = "k8s.io"

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -46,6 +46,7 @@ import (
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
 	"github.com/containerd/cri-containerd/pkg/annotations"
+	"github.com/containerd/cri-containerd/pkg/constants"
 	customopts "github.com/containerd/cri-containerd/pkg/containerd/opts"
 	cio "github.com/containerd/cri-containerd/pkg/server/io"
 	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
@@ -727,7 +728,7 @@ func setOCINamespaces(g *generate.Generator, namespaces *runtime.NamespaceOption
 // defaultRuntimeSpec returns a default runtime spec used in cri-containerd.
 func defaultRuntimeSpec(id string) (*runtimespec.Spec, error) {
 	// GenerateSpec needs namespace.
-	ctx := namespaces.WithNamespace(context.Background(), k8sContainerdNamespace)
+	ctx := namespaces.WithNamespace(context.Background(), constants.K8sContainerdNamespace)
 	spec, err := oci.GenerateSpec(ctx, nil, &containers.Container{ID: id})
 	if err != nil {
 		return nil, err

--- a/pkg/server/instrumented_service.go
+++ b/pkg/server/instrumented_service.go
@@ -19,15 +19,17 @@ package server
 import (
 	"errors"
 
+	"github.com/containerd/containerd/namespaces"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
 	api "github.com/containerd/cri-containerd/pkg/api/v1"
+	"github.com/containerd/cri-containerd/pkg/constants"
 	"github.com/containerd/cri-containerd/pkg/log"
 )
 
-// instrumentedService wraps service and logs each operation.
+// instrumentedService wraps service with containerd namespace and logs.
 type instrumentedService struct {
 	c *criContainerdService
 }
@@ -59,6 +61,7 @@ func (in *instrumentedService) RunPodSandbox(ctx context.Context, r *runtime.Run
 			logrus.Infof("RunPodSandbox for %+v returns sandbox id %q", r.GetConfig().GetMetadata(), res.GetPodSandboxId())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.RunPodSandbox(ctx, r)
 }
 
@@ -74,6 +77,7 @@ func (in *instrumentedService) ListPodSandbox(ctx context.Context, r *runtime.Li
 			log.Tracef("ListPodSandbox returns pod sandboxes %+v", res.GetItems())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.ListPodSandbox(ctx, r)
 }
 
@@ -89,6 +93,7 @@ func (in *instrumentedService) PodSandboxStatus(ctx context.Context, r *runtime.
 			log.Tracef("PodSandboxStatus for %q returns status %+v", r.GetPodSandboxId(), res.GetStatus())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.PodSandboxStatus(ctx, r)
 }
 
@@ -104,6 +109,7 @@ func (in *instrumentedService) StopPodSandbox(ctx context.Context, r *runtime.St
 			logrus.Infof("StopPodSandbox for %q returns successfully", r.GetPodSandboxId())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.StopPodSandbox(ctx, r)
 }
 
@@ -119,6 +125,7 @@ func (in *instrumentedService) RemovePodSandbox(ctx context.Context, r *runtime.
 			logrus.Infof("RemovePodSandbox %q returns successfully", r.GetPodSandboxId())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.RemovePodSandbox(ctx, r)
 }
 
@@ -134,6 +141,7 @@ func (in *instrumentedService) PortForward(ctx context.Context, r *runtime.PortF
 			logrus.Infof("Portforward for %q returns URL %q", r.GetPodSandboxId(), res.GetUrl())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.PortForward(ctx, r)
 }
 
@@ -152,6 +160,7 @@ func (in *instrumentedService) CreateContainer(ctx context.Context, r *runtime.C
 				r.GetPodSandboxId(), r.GetConfig().GetMetadata(), res.GetContainerId())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.CreateContainer(ctx, r)
 }
 
@@ -167,6 +176,7 @@ func (in *instrumentedService) StartContainer(ctx context.Context, r *runtime.St
 			logrus.Infof("StartContainer for %q returns successfully", r.GetContainerId())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.StartContainer(ctx, r)
 }
 
@@ -183,6 +193,7 @@ func (in *instrumentedService) ListContainers(ctx context.Context, r *runtime.Li
 				r.GetFilter(), res.GetContainers())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.ListContainers(ctx, r)
 }
 
@@ -198,6 +209,7 @@ func (in *instrumentedService) ContainerStatus(ctx context.Context, r *runtime.C
 			log.Tracef("ContainerStatus for %q returns status %+v", r.GetContainerId(), res.GetStatus())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.ContainerStatus(ctx, r)
 }
 
@@ -213,6 +225,7 @@ func (in *instrumentedService) StopContainer(ctx context.Context, r *runtime.Sto
 			logrus.Infof("StopContainer for %q returns successfully", r.GetContainerId())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.StopContainer(ctx, r)
 }
 
@@ -228,6 +241,7 @@ func (in *instrumentedService) RemoveContainer(ctx context.Context, r *runtime.R
 			logrus.Infof("RemoveContainer for %q returns successfully", r.GetContainerId())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.RemoveContainer(ctx, r)
 }
 
@@ -245,6 +259,7 @@ func (in *instrumentedService) ExecSync(ctx context.Context, r *runtime.ExecSync
 				res.GetStdout(), res.GetStderr())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.ExecSync(ctx, r)
 }
 
@@ -261,6 +276,7 @@ func (in *instrumentedService) Exec(ctx context.Context, r *runtime.ExecRequest)
 			logrus.Infof("Exec for %q returns URL %q", r.GetContainerId(), res.GetUrl())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.Exec(ctx, r)
 }
 
@@ -276,6 +292,7 @@ func (in *instrumentedService) Attach(ctx context.Context, r *runtime.AttachRequ
 			logrus.Infof("Attach for %q returns URL %q", r.GetContainerId(), res.Url)
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.Attach(ctx, r)
 }
 
@@ -291,6 +308,7 @@ func (in *instrumentedService) UpdateContainerResources(ctx context.Context, r *
 			logrus.Infof("UpdateContainerResources for %q returns successfully", r.GetContainerId())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.UpdateContainerResources(ctx, r)
 }
 
@@ -307,6 +325,7 @@ func (in *instrumentedService) PullImage(ctx context.Context, r *runtime.PullIma
 				r.GetImage().GetImage(), res.GetImageRef())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.PullImage(ctx, r)
 }
 
@@ -323,6 +342,7 @@ func (in *instrumentedService) ListImages(ctx context.Context, r *runtime.ListIm
 				r.GetFilter(), res.GetImages())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.ListImages(ctx, r)
 }
 
@@ -339,6 +359,7 @@ func (in *instrumentedService) ImageStatus(ctx context.Context, r *runtime.Image
 				r.GetImage().GetImage(), res.GetImage())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.ImageStatus(ctx, r)
 }
 
@@ -354,6 +375,7 @@ func (in *instrumentedService) RemoveImage(ctx context.Context, r *runtime.Remov
 			logrus.Infof("RemoveImage %q returns successfully", r.GetImage().GetImage())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.RemoveImage(ctx, r)
 }
 
@@ -369,6 +391,7 @@ func (in *instrumentedService) ImageFsInfo(ctx context.Context, r *runtime.Image
 			logrus.Debugf("ImageFsInfo returns filesystem info %+v", res.ImageFilesystems)
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.ImageFsInfo(ctx, r)
 }
 
@@ -384,6 +407,7 @@ func (in *instrumentedService) ContainerStats(ctx context.Context, r *runtime.Co
 			logrus.Debugf("ContainerStats for %q returns stats %+v", r.GetContainerId(), res.GetStats())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.ContainerStats(ctx, r)
 }
 
@@ -399,6 +423,7 @@ func (in *instrumentedService) ListContainerStats(ctx context.Context, r *runtim
 			log.Tracef("ListContainerStats returns stats %+v", res.GetStats())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.ListContainerStats(ctx, r)
 }
 
@@ -414,6 +439,7 @@ func (in *instrumentedService) Status(ctx context.Context, r *runtime.StatusRequ
 			log.Tracef("Status returns status %+v", res.GetStatus())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.Status(ctx, r)
 }
 
@@ -429,6 +455,7 @@ func (in *instrumentedService) Version(ctx context.Context, r *runtime.VersionRe
 			log.Tracef("Version returns %+v", res)
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.Version(ctx, r)
 }
 
@@ -444,6 +471,7 @@ func (in *instrumentedService) UpdateRuntimeConfig(ctx context.Context, r *runti
 			logrus.Debug("UpdateRuntimeConfig returns returns successfully")
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.UpdateRuntimeConfig(ctx, r)
 }
 
@@ -459,6 +487,7 @@ func (in *instrumentedService) LoadImage(ctx context.Context, r *api.LoadImageRe
 			logrus.Debugf("LoadImage returns images %+v", res.GetImages())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.LoadImage(ctx, r)
 }
 
@@ -474,5 +503,6 @@ func (in *instrumentedService) ReopenContainerLog(ctx context.Context, r *runtim
 			logrus.Debugf("ReopenContainerLog for %q returns successfully", r.GetContainerId())
 		}
 	}()
+	ctx = namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
 	return in.c.ReopenContainerLog(ctx, r)
 }

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/plugin"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	runcapparmor "github.com/opencontainers/runc/libcontainer/apparmor"
@@ -37,6 +38,7 @@ import (
 	api "github.com/containerd/cri-containerd/pkg/api/v1"
 	"github.com/containerd/cri-containerd/pkg/atomic"
 	criconfig "github.com/containerd/cri-containerd/pkg/config"
+	"github.com/containerd/cri-containerd/pkg/constants"
 	osinterface "github.com/containerd/cri-containerd/pkg/os"
 	"github.com/containerd/cri-containerd/pkg/registrar"
 	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
@@ -163,7 +165,8 @@ func (c *criContainerdService) Run(client *containerd.Client) error {
 	c.eventMonitor.subscribe(c.client)
 
 	logrus.Infof("Start recovering state")
-	if err := c.recover(context.Background()); err != nil {
+	ctx := namespaces.WithNamespace(context.Background(), constants.K8sContainerdNamespace)
+	if err := c.recover(ctx); err != nil {
 		return fmt.Errorf("failed to recover state: %v", err)
 	}
 

--- a/vendor/github.com/containerd/containerd/grpc_services.go
+++ b/vendor/github.com/containerd/containerd/grpc_services.go
@@ -60,6 +60,8 @@ func newGRPCServices(address string, copts clientOpts) (Services, error) {
 	if len(copts.dialOptions) > 0 {
 		gopts = copts.dialOptions
 	}
+	// TODO(random-liu): Figure out whether we still need this.
+	// (containerd/containerd#2183)
 	if copts.defaultns != "" {
 		unary, stream := newNSInterceptors(copts.defaultns)
 		gopts = append(gopts,

--- a/vendor/github.com/containerd/containerd/grpc_services.go
+++ b/vendor/github.com/containerd/containerd/grpc_services.go
@@ -1,0 +1,170 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package containerd
+
+import (
+	"time"
+
+	containersapi "github.com/containerd/containerd/api/services/containers/v1"
+	contentapi "github.com/containerd/containerd/api/services/content/v1"
+	diffapi "github.com/containerd/containerd/api/services/diff/v1"
+	eventsapi "github.com/containerd/containerd/api/services/events/v1"
+	imagesapi "github.com/containerd/containerd/api/services/images/v1"
+	introspectionapi "github.com/containerd/containerd/api/services/introspection/v1"
+	leasesapi "github.com/containerd/containerd/api/services/leases/v1"
+	namespacesapi "github.com/containerd/containerd/api/services/namespaces/v1"
+	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
+	"github.com/containerd/containerd/api/services/tasks/v1"
+	versionservice "github.com/containerd/containerd/api/services/version/v1"
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/dialer"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// grpcServices is an implementation of Services through grpc connection
+// with containerd grpc server.
+type grpcServices struct {
+	conn      *grpc.ClientConn
+	connector func() (*grpc.ClientConn, error)
+}
+
+func newGRPCServices(address string, copts clientOpts) (Services, error) {
+	gopts := []grpc.DialOption{
+		grpc.WithBlock(),
+		grpc.WithInsecure(),
+		grpc.WithTimeout(60 * time.Second),
+		grpc.FailOnNonTempDialError(true),
+		grpc.WithBackoffMaxDelay(3 * time.Second),
+		grpc.WithDialer(dialer.Dialer),
+	}
+	if len(copts.dialOptions) > 0 {
+		gopts = copts.dialOptions
+	}
+	if copts.defaultns != "" {
+		unary, stream := newNSInterceptors(copts.defaultns)
+		gopts = append(gopts,
+			grpc.WithUnaryInterceptor(unary),
+			grpc.WithStreamInterceptor(stream),
+		)
+	}
+	connector := func() (*grpc.ClientConn, error) {
+		conn, err := grpc.Dial(dialer.DialAddress(address), gopts...)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to dial %q", address)
+		}
+		return conn, nil
+	}
+	conn, err := connector()
+	if err != nil {
+		return nil, err
+	}
+	return &grpcServices{
+		conn:      conn,
+		connector: connector,
+	}, nil
+}
+
+func newGRPCServicesWithConn(conn *grpc.ClientConn) (Services, error) {
+	return &grpcServices{
+		conn: conn,
+	}, nil
+}
+
+// Reconnect re-establishes the GRPC connection to the containerd daemon
+func (g *grpcServices) Reconnect() error {
+	if g.connector == nil {
+		return errors.New("unable to reconnect to containerd, no connector available")
+	}
+	g.conn.Close()
+	conn, err := g.connector()
+	if err != nil {
+		return err
+	}
+	g.conn = conn
+	return nil
+}
+
+// Close closes the clients connection to containerd
+func (g *grpcServices) Close() error {
+	return g.conn.Close()
+}
+
+// NamespaceService returns the underlying Namespaces Store
+func (g *grpcServices) NamespaceService() namespaces.Store {
+	return NewNamespaceStoreFromClient(namespacesapi.NewNamespacesClient(g.conn))
+}
+
+// ContainerService returns the underlying container Store
+func (g *grpcServices) ContainerService() containers.Store {
+	return NewRemoteContainerStore(containersapi.NewContainersClient(g.conn))
+}
+
+// ContentStore returns the underlying content Store
+func (g *grpcServices) ContentStore() content.Store {
+	return NewContentStoreFromClient(contentapi.NewContentClient(g.conn))
+}
+
+// SnapshotService returns the underlying snapshotter for the provided snapshotter name
+func (g *grpcServices) SnapshotService(snapshotterName string) snapshots.Snapshotter {
+	return NewSnapshotterFromClient(snapshotsapi.NewSnapshotsClient(g.conn), snapshotterName)
+}
+
+// TaskService returns the underlying TasksClient
+func (g *grpcServices) TaskService() tasks.TasksClient {
+	return tasks.NewTasksClient(g.conn)
+}
+
+// ImageService returns the underlying image Store
+func (g *grpcServices) ImageService() images.Store {
+	return NewImageStoreFromClient(imagesapi.NewImagesClient(g.conn))
+}
+
+// DiffService returns the underlying Differ
+func (g *grpcServices) DiffService() DiffService {
+	return NewDiffServiceFromClient(diffapi.NewDiffClient(g.conn))
+}
+
+// IntrospectionService returns the underlying Introspection Client
+func (g *grpcServices) IntrospectionService() introspectionapi.IntrospectionClient {
+	return introspectionapi.NewIntrospectionClient(g.conn)
+}
+
+// LeasesService returns the underlying Leases Client
+func (g *grpcServices) LeasesService() leasesapi.LeasesClient {
+	return leasesapi.NewLeasesClient(g.conn)
+}
+
+// HealthService returns the underlying GRPC HealthClient
+func (g *grpcServices) HealthService() grpc_health_v1.HealthClient {
+	return grpc_health_v1.NewHealthClient(g.conn)
+}
+
+// EventService returns the underlying EventsClient
+func (g *grpcServices) EventService() eventsapi.EventsClient {
+	return eventsapi.NewEventsClient(g.conn)
+}
+
+// VersionService returns the underlying VersionClient
+func (g *grpcServices) VersionService() versionservice.VersionClient {
+	return versionservice.NewVersionClient(g.conn)
+}

--- a/vendor/github.com/containerd/containerd/lease.go
+++ b/vendor/github.com/containerd/containerd/lease.go
@@ -36,7 +36,7 @@ type Lease struct {
 
 // CreateLease creates a new lease
 func (c *Client) CreateLease(ctx context.Context) (Lease, error) {
-	lapi := leasesapi.NewLeasesClient(c.conn)
+	lapi := c.LeasesService()
 	resp, err := lapi.Create(ctx, &leasesapi.CreateRequest{})
 	if err != nil {
 		return Lease{}, err
@@ -50,7 +50,7 @@ func (c *Client) CreateLease(ctx context.Context) (Lease, error) {
 
 // ListLeases lists active leases
 func (c *Client) ListLeases(ctx context.Context) ([]Lease, error) {
-	lapi := leasesapi.NewLeasesClient(c.conn)
+	lapi := c.LeasesService()
 	resp, err := lapi.List(ctx, &leasesapi.ListRequest{})
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func (l Lease) CreatedAt() time.Time {
 // Delete deletes the lease, removing the reference to all resources created
 // during the lease.
 func (l Lease) Delete(ctx context.Context) error {
-	lapi := leasesapi.NewLeasesClient(l.client.conn)
+	lapi := l.client.LeasesService()
 	_, err := lapi.Delete(ctx, &leasesapi.DeleteRequest{
 		ID: l.id,
 	})

--- a/vendor/github.com/containerd/containerd/local_services.go
+++ b/vendor/github.com/containerd/containerd/local_services.go
@@ -1,0 +1,167 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package containerd
+
+import (
+	"time"
+
+	containersapi "github.com/containerd/containerd/api/services/containers/v1"
+	contentapi "github.com/containerd/containerd/api/services/content/v1"
+	diffapi "github.com/containerd/containerd/api/services/diff/v1"
+	eventsapi "github.com/containerd/containerd/api/services/events/v1"
+	imagesapi "github.com/containerd/containerd/api/services/images/v1"
+	introspectionapi "github.com/containerd/containerd/api/services/introspection/v1"
+	leasesapi "github.com/containerd/containerd/api/services/leases/v1"
+	namespacesapi "github.com/containerd/containerd/api/services/namespaces/v1"
+	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
+	"github.com/containerd/containerd/api/services/tasks/v1"
+	versionservice "github.com/containerd/containerd/api/services/version/v1"
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/dialer"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// localServices is an implementation of Services through local function call.
+type localServices struct {
+	conn      *grpc.ClientConn
+	connector func() (*grpc.ClientConn, error)
+}
+
+// NewLocalServices returns a new services using the passed-in
+// local services.
+// Users of local services need to handle namespace themselves.
+// TODO(random-liu): Change all services to local services and remove
+// the grpc connection.
+// TODO(random-liu): Design the arg list better, probably
+// need some option functions. (containerd/containerd#2183)
+func NewLocalServices(address, ns string) (Services, error) {
+	gopts := []grpc.DialOption{
+		grpc.WithBlock(),
+		grpc.WithInsecure(),
+		grpc.WithTimeout(60 * time.Second),
+		grpc.FailOnNonTempDialError(true),
+		grpc.WithBackoffMaxDelay(3 * time.Second),
+		grpc.WithDialer(dialer.Dialer),
+	}
+	if ns != "" {
+		unary, stream := newNSInterceptors(ns)
+		gopts = append(gopts,
+			grpc.WithUnaryInterceptor(unary),
+			grpc.WithStreamInterceptor(stream),
+		)
+	}
+	connector := func() (*grpc.ClientConn, error) {
+		conn, err := grpc.Dial(dialer.DialAddress(address), gopts...)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to dial %q", address)
+		}
+		return conn, nil
+	}
+	conn, err := connector()
+	if err != nil {
+		return nil, err
+	}
+	return &localServices{
+		conn:      conn,
+		connector: connector,
+	}, nil
+}
+
+// Reconnect re-establishes the GRPC connection to the containerd daemon
+func (l *localServices) Reconnect() error {
+	if l.connector == nil {
+		return errors.New("unable to reconnect to containerd, no connector available")
+	}
+	l.conn.Close()
+	conn, err := l.connector()
+	if err != nil {
+		return err
+	}
+	l.conn = conn
+	return nil
+}
+
+// Close closes the clients connection to containerd
+func (l *localServices) Close() error {
+	return l.conn.Close()
+}
+
+// NamespaceService returns the underlying Namespaces Store
+func (l *localServices) NamespaceService() namespaces.Store {
+	return NewNamespaceStoreFromClient(namespacesapi.NewNamespacesClient(l.conn))
+}
+
+// ContainerService returns the underlying container Store
+func (l *localServices) ContainerService() containers.Store {
+	return NewRemoteContainerStore(containersapi.NewContainersClient(l.conn))
+}
+
+// ContentStore returns the underlying content Store
+func (l *localServices) ContentStore() content.Store {
+	return NewContentStoreFromClient(contentapi.NewContentClient(l.conn))
+}
+
+// SnapshotService returns the underlying snapshotter for the provided snapshotter name
+func (l *localServices) SnapshotService(snapshotterName string) snapshots.Snapshotter {
+	return NewSnapshotterFromClient(snapshotsapi.NewSnapshotsClient(l.conn), snapshotterName)
+}
+
+// TaskService returns the underlying TasksClient
+func (l *localServices) TaskService() tasks.TasksClient {
+	return tasks.NewTasksClient(l.conn)
+}
+
+// ImageService returns the underlying image Store
+func (l *localServices) ImageService() images.Store {
+	return NewImageStoreFromClient(imagesapi.NewImagesClient(l.conn))
+}
+
+// DiffService returns the underlying Differ
+func (l *localServices) DiffService() DiffService {
+	return NewDiffServiceFromClient(diffapi.NewDiffClient(l.conn))
+}
+
+// IntrospectionService returns the underlying Introspection Client
+func (l *localServices) IntrospectionService() introspectionapi.IntrospectionClient {
+	return introspectionapi.NewIntrospectionClient(l.conn)
+}
+
+// LeasesService returns the underlying Leases Client
+func (l *localServices) LeasesService() leasesapi.LeasesClient {
+	return leasesapi.NewLeasesClient(l.conn)
+}
+
+// HealthService returns the underlying GRPC HealthClient
+func (l *localServices) HealthService() grpc_health_v1.HealthClient {
+	return grpc_health_v1.NewHealthClient(l.conn)
+}
+
+// EventService returns the underlying EventsClient
+func (l *localServices) EventService() eventsapi.EventsClient {
+	return eventsapi.NewEventsClient(l.conn)
+}
+
+// VersionService returns the underlying VersionClient
+func (l *localServices) VersionService() versionservice.VersionClient {
+	return versionservice.NewVersionClient(l.conn)
+}


### PR DESCRIPTION
@crosbymichael @mikebrow Let's start from this PR. Once we are ok with this PR, we can port services one by one without interfering each other.

This PR:
1) Added a `Services` interface in `Client.go`. And added grpcServices implementation and also a directServices implementation. Suggestions for naming are welcome.
2) Added `k8s.io` namespace for all contexts in cri plugin. We can also deal with default namespace in containerd client, but without grpc it requires too many changes. It might be easier to let caller handle namespace if direct services are used.
3) Change CRI plugin to use internal content store.

Please note that **the internal content store doesn't publish events**. Should we fix it? Or we are ok with it?
/cc @containerd/containerd-maintainers 