### PR TITLE
Handles 401 in resolver.

### DIFF
--- a/pkg/containerd/resolver/resolver.go
+++ b/pkg/containerd/resolver/resolver.go
@@ -501,7 +501,7 @@ func (r *dockerBase) fetchTokenWithOAuth(ctx context.Context, to tokenOptions) (
 
 	// Registries without support for POST may return 404 for POST /v2/token.
 	// As of September 2017, GCR is known to return 404.
-	if (resp.StatusCode == 405 && r.username != "") || resp.StatusCode == 404 {
+	if (resp.StatusCode == 405 && r.username != "") || resp.StatusCode == 404 || resp.StatusCode == 401 {
 		return r.getToken(ctx, to)
 	} else if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		b, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 64000)) // 64KB


### PR DESCRIPTION
Fixes https://github.com/containerd/cri-containerd/issues/649.
Ref https://github.com/containerd/cri-containerd/issues/642.

GCR sometimes returns http 401 since this noon, which caused many test failures, e.g. https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce/2908. 

I've filed an internal issue to them. Before that is fixed let's port the fix https://github.com/containerd/containerd/pull/2171 here, which we need anyway.

@abhi 

Signed-off-by: Lantao Liu <lantaol@google.com>